### PR TITLE
[backports] Cleaner construction via config structure, more tests

### DIFF
--- a/src/cmd/main/main.go
+++ b/src/cmd/main/main.go
@@ -12,50 +12,36 @@ import (
 
 func main() {
 	// Define flags
-	require_images := flag.Bool("require_images", true, "Whether the items require images")
-	require_embeddings := flag.Bool("require_embeddings", false, "Whether the items require the DB embeddings")
+	client_config := datago.GetDefaultConfig()
+	client_config.DefaultImageSize = 1024
+	client_config.DownsamplingRatio = 32
 
-	crop_and_resize := flag.Bool("crop_and_resize", false, "Whether to crop and resize the images and masks")
+	client_config.CropAndResize = *flag.Bool("crop_and_resize", false, "Whether to crop and resize the images and masks")
+	client_config.ConcurrentDownloads = *flag.Int("concurrency", 64, "The number of concurrent http requests to make")
+	client_config.PrefetchBufferSize = *flag.Int("item_fetch_buffer", 256, "The number of items to pre-load")
+	client_config.SamplesBufferSize = *flag.Int("item_ready_buffer", 128, "The number of items ready to be served")
 
-	concurrency := flag.Int("concurrency", 64, "The number of concurrent http requests to make")
-	item_fetch_buffer := flag.Int("item_fetch_buffer", 256, "The number of items to pre-load")
-	item_ready_buffer := flag.Int("item_ready_buffer", 128, "The number of items ready to be served")
+	client_config.Sources = *flag.String("source", "GETTY", "The source for the items")
+	client_config.RequireImages = *flag.Bool("require_images", true, "Whether the items require images")
+	client_config.RequireEmbeddings = *flag.Bool("require_embeddings", false, "Whether the items require the DB embeddings")
+
+	client_config.Tags = *flag.String("tags", "", "The tags to filter for")
+	client_config.TagsNE = *flag.String("tags__ne", "", "The tags that the samples should not have")
+	client_config.HasMasks = *flag.String("has_masks", "", "The masks to filter for")
+	client_config.HasLatents = *flag.String("has_latents", "", "The masks to filter for")
+	client_config.HasAttributes = *flag.String("has_attributes", "", "The attributes to filter for")
+
+	client_config.LacksMasks = *flag.String("lacks_masks", "", "The masks to filter against")
+	client_config.LacksLatents = *flag.String("lacks_latents", "", "The masks to filter against")
+	client_config.LacksAttributes = *flag.String("lacks_attributes", "", "The attributes to filter against")
+
 	limit := flag.Int("limit", 2000, "The number of items to fetch")
-	source := flag.String("source", "SOURCE", "The source for the items")
-
-	tags := flag.String("tags", "", "The tags to filter for")
-	tags__ne := flag.String("tags__ne", "", "The tags used for inversed filtering")
-
-	has_masks := flag.String("has_masks", "", "The masks to filter for")
-	has_latents := flag.String("has_latents", "", "The masks to filter for")
-	has_attributes := flag.String("has_attributes", "", "The attributes to filter for")
-
-	lacks_masks := flag.String("lacks_masks", "", "The masks to filter against")
-	lacks_latents := flag.String("lacks_latents", "", "The masks to filter against")
-	lacks_attributes := flag.String("lacks_attributes", "", "The attributes to filter against")
-
 	profile := flag.Bool("profile", false, "Whether to profile the code")
 
 	// Parse the flags and instantiate the client
 	flag.Parse()
-	rank := uint32(0)
-	world_size := uint32(1)
 
-	dataroom_client := datago.GetClient(
-		*source,
-		*require_images,
-		*require_embeddings,
-		*tags, *tags__ne,
-		*has_attributes, *lacks_attributes,
-		*has_masks, *lacks_masks,
-		*has_latents, *lacks_latents,
-		*crop_and_resize,
-		1024, 32, false,
-		rank, world_size,
-		*item_fetch_buffer,
-		*item_ready_buffer,
-		*concurrency,
-	)
+	dataroom_client := datago.GetClient(client_config)
 
 	// Go-routine which will feed the sample data to the workers
 	// and fetch the next page

--- a/src/pkg/client/transforms.go
+++ b/src/pkg/client/transforms.go
@@ -7,12 +7,6 @@ import (
 	"github.com/davidbyttow/govips/v2/vips"
 )
 
-func checkError(error error) {
-	if error != nil {
-		fmt.Println(error)
-	}
-}
-
 type ImageSize struct {
 	// Making it explicit how we store width and height, guarding against potential confusion
 	Width  int
@@ -113,8 +107,7 @@ func (t *ARAwareTransform) cropAndResizeToClosestAspectRatio(image *vips.ImageRe
 	// Desired target size is a lookup away, this is pre-computed/bucketed
 	targetSize := t.aspectRatioToSize[referenceAR]
 
-	// Trust libvips to do resize and crop in one go.
-	// Note that jpg decoding happens here and can fail
+	// Trust libvips to do resize and crop in one go. Note that jpg decoding happens here and can fail
 	err := image.ThumbnailWithSize(targetSize.Width, targetSize.Height, vips.InterestingCentre, vips.SizeBoth)
 	return referenceAR, err
 }

--- a/src/tests/client_test.go
+++ b/src/tests/client_test.go
@@ -1,21 +1,36 @@
 package datago_test
 
 import (
+	"os"
 	"testing"
 
 	datago "datago/pkg/client"
+
+	"github.com/davidbyttow/govips/v2/vips"
 )
 
+func get_test_source() string {
+	return os.Getenv("DATAROOM_TEST_SOURCE")
+}
+
 func TestClientStartStop(t *testing.T) {
+	config := datago.GetDefaultConfig()
+	config.Sources = get_test_source()
+	config.PageSize = 32
+
 	// Check that we can start, do nothing and stop the client immediately
-	client := datago.GetClient("SOURCE", true, false, "", "", "", "", "", "", "", "", false, 1024, 16, false, 0, 1, 8, 8, 2)
+	client := datago.GetClient(config)
 	client.Start()
 	client.Stop()
 }
 
 func TestClientNoStart(t *testing.T) {
-	// Check that we can start, do nothing and stop the client immediately
-	client := datago.GetClient("SOURCE", true, false, "", "", "", "", "", "", "", "", false, 1024, 16, false, 0, 1, 8, 8, 2)
+	config := datago.GetDefaultConfig()
+	config.Sources = get_test_source()
+	config.PageSize = 32
+
+	// Check that we can get a sample without starting the client
+	client := datago.GetClient(config)
 	sample := client.GetSample()
 	if sample.ID == "" {
 		t.Errorf("GetSample returned an unexpected error")
@@ -23,17 +38,45 @@ func TestClientNoStart(t *testing.T) {
 }
 
 func TestClientNoStop(t *testing.T) {
-	// Check that we can start, do nothing and destroy the client immediately
+	// Check that we can start, get a sample, and destroy the client immediately
 	// In that case Stop() should be called in the background, and everything should work just fine
-	client := datago.GetClient("SOURCE", true, false, "", "", "", "", "", "", "", "", false, 1024, 16, false, 0, 1, 8, 8, 2)
+	config := datago.GetDefaultConfig()
+	config.Sources = get_test_source()
+	config.PageSize = 32
+	config.SamplesBufferSize = 1
+
+	client := datago.GetClient(config)
 	client.Start()
 	_ = client.GetSample()
 
 }
 
-func TestFetchImage(t *testing.T) {
-	client := datago.GetClient("SOURCE", true, false, "", "", "", "", "", "", "", "", false, 1024, 16, false, 0, 1, 8, 8, 2)
+func TestMoreThanBufferSize(t *testing.T) {
+	// Check that we can start, get a sample, and destroy the client immediately
+	// In that case Stop() should be called in the background, and everything should work just fine
+	config := datago.GetDefaultConfig()
+	config.Sources = get_test_source()
+	config.PageSize = 32
+	config.SamplesBufferSize = 1
+
+	client := datago.GetClient(config)
 	client.Start()
+	_ = client.GetSample()
+
+	if client.GetSample().ID == "" {
+		t.Errorf("GetSample returned an unexpected error")
+	}
+}
+
+func TestFetchImage(t *testing.T) {
+	config := datago.GetDefaultConfig()
+	config.Sources = get_test_source()
+	config.RequireImages = true
+	config.PageSize = 32
+	config.SamplesBufferSize = 1
+
+	// Check that we can get an image
+	client := datago.GetClient(config)
 	sample := client.GetSample()
 
 	// Assert that no error occurred
@@ -46,11 +89,53 @@ func TestFetchImage(t *testing.T) {
 		t.Errorf("Expected non-nil sample")
 	}
 
+	// Check the buffer size
+	if len(sample.Image.Data) != sample.Image.Height*sample.Image.Width*3 {
+		t.Errorf("Expected image buffer size to be Height*Width*3")
+	}
+
+	client.Stop()
+}
+
+func TestExtraFields(t *testing.T) {
+	config := datago.GetDefaultConfig()
+	config.Sources = get_test_source()
+	config.RequireImages = true
+	config.PageSize = 32
+	config.HasLatents = "masked_image"
+	config.HasMasks = "segmentation_mask"
+	config.SamplesBufferSize = 1
+
+	// Check that we can get an image
+	client := datago.GetClient(config)
+	sample := client.GetSample()
+
+	// Assert that no error occurred
+	if sample.ID == "" {
+		t.Errorf("GetSample returned an unexpected error")
+	}
+
+	// Assert that we have the expected fields in the sample
+	if _, exists := sample.AdditionalImages["masked_image"]; !exists {
+
+		t.Errorf("Sample is missing the required field %s", "masked_image")
+	}
+
+	if _, exists := sample.Masks["segmentation_mask"]; !exists {
+		t.Errorf("Sample is missing the required field %s", "segmentation_mask")
+	}
+
 	client.Stop()
 }
 
 func TestCropAndResize(t *testing.T) {
-	client := datago.GetClient("SOURCE", true, false, "", "", "", "", "segmentation_mask", "", "masked_image", "", true, 1024, 16, false, 0, 1, 8, 8, 2)
+	config := datago.GetDefaultConfig()
+	config.Sources = get_test_source()
+	config.RequireImages = true
+	config.PageSize = 32
+	config.CropAndResize = true
+
+	client := datago.GetClient(config)
 	client.Start()
 
 	for i := 0; i < 10; i++ {
@@ -72,8 +157,65 @@ func TestCropAndResize(t *testing.T) {
 				t.Errorf("Expected cropped and resized mask %s", k)
 			}
 		}
+
+		for k, v := range sample.AdditionalImages {
+			if v.Height != sample.Image.Height || v.Width != sample.Image.Width {
+				t.Errorf("Expected cropped and resized image %s", k)
+			}
+		}
 	}
 	client.Stop()
 }
 
-// TODO: ask for something which doesn't exist
+func TestImageBufferCompression(t *testing.T) {
+	// Check that the image buffer is compressed, and that we can decode it properly
+	config := datago.GetDefaultConfig()
+	config.Sources = get_test_source()
+	config.RequireImages = true
+	config.PageSize = 32
+	config.CropAndResize = true
+	config.HasLatents = "masked_image"
+	config.HasMasks = "segmentation_mask"
+	config.PreEncodeImages = true
+	client := datago.GetClient(config)
+	sample := client.GetSample()
+
+	// Check that no error occurred
+	if sample.ID == "" {
+		t.Errorf("GetSample returned an unexpected error")
+	}
+
+	// Check that the image buffers are compressed, and we can decode them properly
+	// -- Test the base image
+	if sample.Image.Channels != -1 {
+		t.Errorf("Expected compressed image buffer")
+	}
+
+	decoded_image, err := vips.NewImageFromBuffer(sample.Image.Data)
+	if err != nil {
+		t.Errorf("Error decoding image buffer")
+	}
+	if decoded_image.Width() != sample.Image.Width || decoded_image.Height() != sample.Image.Height {
+		t.Errorf("Decoded image has unexpected dimensions %d %d %d %d", decoded_image.Width(), decoded_image.Height(), sample.Image.Width, sample.Image.Height)
+	}
+
+	// -- Test the additional images (will be png compressed)
+	if sample.AdditionalImages["masked_image"].Channels != -1 {
+		t.Errorf("Expected compressed masked image buffer")
+	}
+
+	_, err = vips.NewImageFromBuffer(sample.AdditionalImages["masked_image"].Data)
+	if err != nil {
+		t.Errorf("Error decoding masked image buffer")
+	}
+
+	// -- Test the masks (will be png compressed)
+	if sample.Masks["segmentation_mask"].Channels != -1 {
+		t.Errorf("Expected compressed mask buffer")
+	}
+
+	_, err = vips.NewImageFromBuffer(sample.Masks["segmentation_mask"].Data)
+	if err != nil {
+		t.Errorf("Error decoding mask buffer")
+	}
+}


### PR DESCRIPTION
- request a config structure upon construction, named fields so less error prone
- backport more tests + env define via DATAROOM_TEST_SOURCE