### PR TITLE
[arch] Make it possible to have different backends

### DIFF
--- a/src/pkg/client/backend_http.go
+++ b/src/pkg/client/backend_http.go
@@ -1,0 +1,46 @@
+package datago
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type BackendHTTP struct {
+	config *DataroomClientConfig
+}
+
+func (b BackendHTTP) collectSamples(chanSampleMetadata chan dbSampleMetadata, chanSamples chan Sample, transform *ARAwareTransform) {
+
+	ack_channel := make(chan bool)
+
+	sampleWorker := func() {
+		// One HHTP client per goroutine, make sure we don't run into racing conditions when renewing
+		http_client := http.Client{Timeout: 30 * time.Second}
+
+		for {
+			item_to_fetch, open := <-chanSampleMetadata
+			if !open {
+				ack_channel <- true
+				return
+			}
+
+			sample := fetchSample(b.config, &http_client, item_to_fetch, transform)
+			if sample != nil {
+				chanSamples <- *sample
+			}
+		}
+	}
+
+	// Start the workers and work on the metadata channel
+	for i := 0; i < b.config.ConcurrentDownloads; i++ {
+		go sampleWorker()
+	}
+
+	// Wait for all the workers to be done or overall context to be cancelled
+	for i := 0; i < b.config.ConcurrentDownloads; i++ {
+		<-ack_channel
+	}
+	close(chanSamples)
+	fmt.Println("No more items to serve, wrapping up")
+}


### PR DESCRIPTION
Another step towards #9. 

Eventually Datago will be a dataloader which is organized around a frontend (generates pointers to data) and backend (fetch, deserialize, process, serialize). 

Several frontends and backend are quite easy to implement, currently there's only a DB frontend with a HTTP backend, but adding support for local files or a S3 bucket enumerator and client wouldn´t be too complicated