### PR TITLE
[wip] Dynamic worker pool, not super elegant but actually faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ client_config = {
     # some performance options, best settings will depend on your machine
     "prefetch_buffer_size": 64,
     "samples_buffer_size": 128,
-    "concurrency": concurrency,
 }
 
 client = datago.GetClientFromJSON(json.dumps(config)) # Will return None if something goes wrong, check the logs

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,7 +13,6 @@ import (
 func main() {
 
 	cropAndResize := flag.Bool("crop_and_resize", false, "Whether to crop and resize the images and masks")
-	concurrency := flag.Int("concurrency", 64, "The number of concurrent http requests to make")
 	itemFetchBuffer := flag.Int("item_fetch_buffer", 256, "The number of items to pre-load")
 	itemReadyBuffer := flag.Int("item_ready_buffer", 128, "The number of items ready to be served")
 	limit := flag.Int("limit", 2000, "The number of items to fetch")
@@ -36,9 +35,8 @@ func main() {
 		CropAndResize:     *cropAndResize,
 	}
 	config.SourceConfig = sourceConfig
-	config.Concurrency = *concurrency
-	config.PrefetchBufferSize = *itemFetchBuffer
-	config.SamplesBufferSize = *itemReadyBuffer
+	config.PrefetchBufferSize = int32(*itemFetchBuffer)
+	config.SamplesBufferSize = int32(*itemReadyBuffer)
 	config.Limit = *limit
 
 	dataroom_client := datago.GetClient(config)

--- a/pkg/client.go
+++ b/pkg/client.go
@@ -56,9 +56,8 @@ type DatagoConfig struct {
 	SourceType         DatagoSourceType     `json:"source_type"`
 	SourceConfig       interface{}          `json:"source_config"`
 	ImageConfig        ImageTransformConfig `json:"image_config"`
-	PrefetchBufferSize int                  `json:"prefetch_buffer_size"`
-	SamplesBufferSize  int                  `json:"samples_buffer_size"`
-	Concurrency        int                  `json:"concurrency"`
+	PrefetchBufferSize int32                `json:"prefetch_buffer_size"`
+	SamplesBufferSize  int32                `json:"samples_buffer_size"`
 	Limit              int                  `json:"limit"`
 }
 
@@ -70,7 +69,6 @@ func (c *DatagoConfig) setDefaults() {
 	c.ImageConfig.setDefaults()
 	c.PrefetchBufferSize = 64
 	c.SamplesBufferSize = 32
-	c.Concurrency = 64
 	c.Limit = 0
 }
 
@@ -131,9 +129,8 @@ func DatagoConfigFromJSON(jsonString string) DatagoConfig {
 		log.Panicf("Error unmarshalling Image config: %v", err)
 	}
 
-	config.PrefetchBufferSize = int(tempConfig["prefetch_buffer_size"].(float64))
-	config.SamplesBufferSize = int(tempConfig["samples_buffer_size"].(float64))
-	config.Concurrency = int(tempConfig["concurrency"].(float64))
+	config.PrefetchBufferSize = int32(tempConfig["prefetch_buffer_size"].(float64))
+	config.SamplesBufferSize = int32(tempConfig["samples_buffer_size"].(float64))
 	if err != nil {
 		log.Panicf("Error unmarshalling JSON: %v", err)
 	}
@@ -155,9 +152,9 @@ type DatagoClient struct {
 	backend   Backend
 
 	// Channels	- these will be used to communicate between the background goroutines
-	chanPages          chan Pages
-	chanSampleMetadata chan SampleDataPointers
-	chanSamples        chan Sample
+	chanPages          BufferedChan[Pages]
+	chanSampleMetadata BufferedChan[SampleDataPointers]
+	chanSamples        BufferedChan[Sample]
 }
 
 // -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -187,13 +184,13 @@ func GetClient(config DatagoConfig) *DatagoClient {
 		if err != nil {
 			return nil
 		} else {
-			backend = BackendHTTP{config: &dbConfig, concurrency: config.Concurrency}
+			backend = BackendHTTP{config: &dbConfig}
 		}
 	case SourceFileSystemConfig:
 		fmt.Println("Creating a FileSystem-backed dataloader.", config.Limit, " max samples")
 		fsConfig := config.SourceConfig.(SourceFileSystemConfig)
 		generator = newDatagoGeneratorFileSystem(fsConfig)
-		backend = BackendFileSystem{config: &config, concurrency: config.Concurrency}
+		backend = BackendFileSystem{config: &config}
 	default:
 		fmt.Println("Unsupported source type")
 		log.Panic("Unsupported source type")
@@ -201,9 +198,9 @@ func GetClient(config DatagoConfig) *DatagoClient {
 
 	// Create the client
 	client := &DatagoClient{
-		chanPages:          make(chan Pages, 2),
-		chanSampleMetadata: make(chan SampleDataPointers, config.PrefetchBufferSize),
-		chanSamples:        make(chan Sample, config.SamplesBufferSize),
+		chanPages:          NewBufferedChan[Pages](2),
+		chanSampleMetadata: NewBufferedChan[SampleDataPointers](config.PrefetchBufferSize),
+		chanSamples:        NewBufferedChan[Sample](config.SamplesBufferSize),
 		imageConfig:        config.ImageConfig,
 		servedSamples:      0,
 		limit:              config.Limit,
@@ -264,7 +261,7 @@ func (c *DatagoClient) Start() {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		c.generator.generatePages(c.context, c.chanPages) // Collect the root data source pages
+		c.generator.generatePages(c.context, &c.chanPages) // Collect the root data source pages
 	}()
 
 	wg.Add(1)
@@ -276,7 +273,7 @@ func (c *DatagoClient) Start() {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		c.backend.collectSamples(c.chanSampleMetadata, c.chanSamples, arAwareTransform, c.imageConfig.PreEncodeImages) // Fetch the payloads and and deserialize them
+		c.backend.collectSamples(&c.chanSampleMetadata, &c.chanSamples, arAwareTransform, c.imageConfig.PreEncodeImages) // Fetch the payloads and and deserialize them
 	}()
 
 	c.waitGroup = &wg
@@ -296,7 +293,8 @@ func (c *DatagoClient) GetSample() Sample {
 		return Sample{}
 	}
 
-	if sample, ok := <-c.chanSamples; ok {
+	sample, ok := c.chanSamples.Receive()
+	if ok {
 		c.servedSamples++
 		return sample
 	}
@@ -307,18 +305,16 @@ func (c *DatagoClient) GetSample() Sample {
 
 // Stop the background downloads, will clear the memory and CPU footprint
 func (c *DatagoClient) Stop() {
-	fmt.Println("Stopping the datago client")
 
 	// Signal the coroutines that next round should be a stop
 	if c.cancel == nil {
 		return // Already stopped
 	}
+	fmt.Println("Stopping the datago client")
 	c.cancel()
-
-	// Clear the channels, in case a commit is blocking
-	go consumeChannel(c.chanPages)
-	go consumeChannel(c.chanSampleMetadata)
-	go consumeChannel(c.chanSamples)
+	c.chanPages.Empty()
+	c.chanSampleMetadata.Empty()
+	c.chanSamples.Empty()
 
 	// Wait for all goroutines to finish
 	if c.waitGroup != nil {
@@ -339,22 +335,23 @@ func (c *DatagoClient) asyncDispatch() {
 	for {
 		select {
 		case <-c.context.Done():
-			close(c.chanSampleMetadata)
+			c.chanSampleMetadata.Close()
 			return
-		case page, open := <-c.chanPages:
+		default:
+			page, open := c.chanPages.Receive()
 			if !open {
 				fmt.Println("No more metadata to fetch, wrapping up")
-				close(c.chanSampleMetadata)
+				c.chanSampleMetadata.Close()
 				return
 			}
 
 			for _, item := range page.samplesDataPointers {
 				select {
 				case <-c.context.Done():
-					close(c.chanSampleMetadata)
+					c.chanSampleMetadata.Close()
 					return
-				case c.chanSampleMetadata <- item:
-					// Item sent to the channel
+				default:
+					c.chanSampleMetadata.Send(item)
 				}
 			}
 		}

--- a/pkg/dynamic_pool.go
+++ b/pkg/dynamic_pool.go
@@ -1,0 +1,89 @@
+package datago
+
+import (
+	"fmt"
+	"runtime"
+	"time"
+)
+
+// Define an enum which will be used to track the state of the worker
+type worker_state int
+
+const (
+	worker_idle worker_state = iota
+	worker_running
+	worker_done
+	worker_stopping
+)
+
+// Define a stateful worker struct which will be spawned by the worker pool
+type worker struct {
+	state worker_state
+}
+
+// Manage a pool of workers to fetch the samples
+// We'll initially spawn half the machine capacity in terms of workers,
+// and then we'll dynamically adjust the number of workers based on the
+// work backlog and idle time
+
+func run_worker_pool(sampleWorker func(*worker), chanInputs *BufferedChan[SampleDataPointers], chanOutputs *BufferedChan[Sample]) {
+
+	// Get the number of CPUs on the machine
+	numCPUs := runtime.NumCPU() // We suppose that this doesn´t change during the execution
+	worker_pool_size := numCPUs / 2
+
+	// Start the workers and work on the metadata channel
+	var workers []*worker
+
+	for i := 0; i < worker_pool_size; i++ {
+		new_worker := worker{state: worker_idle}
+		workers = append(workers, &new_worker)
+		go sampleWorker(&new_worker)
+	}
+
+	// Every second, check the state of the workers and adjust the pool size
+	// based on the work backlog and idle time
+	for {
+		// FIXME: Logic is super crude here, although ballpark correct
+		if !idle_workers(workers) && chanInputs.current_items > int32(len(workers)) && len(workers) < numCPUs {
+			fmt.Println("Increasing the worker pool size. Now ", len(workers))
+			new_worker := worker{state: worker_idle}
+			workers = append(workers, &new_worker)
+			go sampleWorker(&new_worker)
+		}
+
+		if idle_workers(workers) && chanInputs.current_items < 10 && len(workers) > 1 {
+			fmt.Println("Decreasing the worker pool size. Now ", len(workers))
+			workers[len(workers)-1].state = worker_stopping
+			workers = workers[:len(workers)-1]
+		}
+
+		if done_workers(workers) {
+			fmt.Println("All workers are done")
+			break
+		}
+		time.Sleep(1 * time.Second)
+		fmt.Println("Samples in the input queue", chanInputs.current_items, " Output queue: ", chanOutputs.current_items)
+	}
+}
+
+func idle_workers(workers []*worker) bool {
+	// There will be some noise measuring this, it's ok, we're only interested in a big picture
+	idle := 0
+	for _, w := range workers {
+		if w.state == worker_idle {
+			idle += 1
+		}
+	}
+	return (float64(idle) / float64(len(workers))) > 0.5
+}
+
+func done_workers(workers []*worker) bool {
+	done := 0
+	for _, w := range workers {
+		if w.state == worker_done {
+			done += 1
+		}
+	}
+	return done == len(workers)
+}

--- a/pkg/serdes.go
+++ b/pkg/serdes.go
@@ -114,7 +114,7 @@ func imageFromBuffer(buffer []byte, transform *ARAwareTransform, aspect_ratio fl
 		bit_depth = len(img_bytes) / (width * height * channels) * 8 // 8 bits per byte
 	}
 
-	if bit_depth == 0 && !pre_encode_image {
+	if bit_depth == 0 && !transform.PreEncodeImages {
 		panic("Bit depth not set")
 	}
 

--- a/pkg/transforms.go
+++ b/pkg/transforms.go
@@ -25,6 +25,7 @@ type ARAwareTransform struct {
 	maxAspectRatio    float64
 	targetImageSizes  []ImageSize // list of [width, height] pairs
 	aspectRatioToSize map[float64]ImageSize
+	PreEncodeImages   bool
 }
 
 func buildImageSizeList(defaultImageSize int, downsamplingRatio int, minAspectRatio float64, maxAspectRatio float64) []ImageSize {

--- a/pkg/worker_filesystem.go
+++ b/pkg/worker_filesystem.go
@@ -6,11 +6,10 @@ import (
 )
 
 type BackendFileSystem struct {
-	config      *DatagoConfig
-	concurrency int
+	config *DatagoConfig
 }
 
-func loadSample(config *DatagoConfig, filesystem_sample fsSampleMetadata, transform *ARAwareTransform, pre_encode_images bool) *Sample {
+func loadSample(filesystem_sample fsSampleMetadata, transform *ARAwareTransform, pre_encode_image bool) *Sample {
 	// Load the file into []bytes
 	bytes_buffer, err := os.ReadFile(filesystem_sample.FilePath)
 	if err != nil {
@@ -18,7 +17,7 @@ func loadSample(config *DatagoConfig, filesystem_sample fsSampleMetadata, transf
 		return nil
 	}
 
-	img_payload, _, err := imageFromBuffer(bytes_buffer, transform, -1., pre_encode_images, false)
+	img_payload, _, err := imageFromBuffer(bytes_buffer, transform, -1., pre_encode_image, false)
 	if err != nil {
 		fmt.Println("Error loading image:", filesystem_sample.FileName)
 		return nil
@@ -29,17 +28,21 @@ func loadSample(config *DatagoConfig, filesystem_sample fsSampleMetadata, transf
 	}
 }
 
-func (b BackendFileSystem) collectSamples(chanSampleMetadata chan SampleDataPointers, chanSamples chan Sample, transform *ARAwareTransform, pre_encode_images bool) {
+func (b BackendFileSystem) collectSamples(inputSampleMetadata *BufferedChan[SampleDataPointers], outputSamples *BufferedChan[Sample], transform *ARAwareTransform, encodeImages bool) {
 
-	ack_channel := make(chan bool)
-
-	sampleWorker := func() {
+	sampleWorker := func(worker_handle *worker) {
 		for {
-			item_to_fetch, open := <-chanSampleMetadata
-			if !open {
-				ack_channel <- true
+			if worker_handle.state == worker_stopping {
+				worker_handle.state = worker_done
 				return
 			}
+			worker_handle.state = worker_idle
+			item_to_fetch, open := inputSampleMetadata.Receive()
+			if !open {
+				worker_handle.state = worker_done
+				return
+			}
+			worker_handle.state = worker_running
 
 			// Cast the item to fetch to the correct type
 			filesystem_sample, ok := item_to_fetch.(fsSampleMetadata)
@@ -47,21 +50,13 @@ func (b BackendFileSystem) collectSamples(chanSampleMetadata chan SampleDataPoin
 				panic("Failed to cast the item to fetch to dbSampleMetadata. This worker is probably misconfigured")
 			}
 
-			sample := loadSample(b.config, filesystem_sample, transform, pre_encode_images)
+			sample := loadSample(filesystem_sample, transform, encodeImages)
 			if sample != nil {
-				chanSamples <- *sample
+				outputSamples.Send(*sample)
 			}
 		}
 	}
 
-	// Start the workers and work on the metadata channel
-	for i := 0; i < b.concurrency; i++ {
-		go sampleWorker()
-	}
-
-	// Wait for all the workers to be done or overall context to be cancelled
-	for i := 0; i < b.concurrency; i++ {
-		<-ack_channel
-	}
-	close(chanSamples)
+	run_worker_pool(sampleWorker, inputSampleMetadata, outputSamples)
+	outputSamples.Close()
 }

--- a/pkg/worker_http.go
+++ b/pkg/worker_http.go
@@ -6,24 +6,23 @@ import (
 )
 
 type BackendHTTP struct {
-	config      *SourceDBConfig
-	concurrency int
+	config *SourceDBConfig
 }
 
-func (b BackendHTTP) collectSamples(chanSampleMetadata chan SampleDataPointers, chanSamples chan Sample, transform *ARAwareTransform, pre_encode_images bool) {
+func (b BackendHTTP) collectSamples(inputSampleMetadata *BufferedChan[SampleDataPointers], outputSamples *BufferedChan[Sample], transform *ARAwareTransform, encodeImages bool) {
 
-	ack_channel := make(chan bool)
-
-	sampleWorker := func() {
-		// One HHTP client per goroutine, make sure we don't run into racing conditions when renewing
+	sampleWorker := func(worker_handle *worker) {
+		// One HHTP client per goroutine, make sure we don't run into race conditions when renewing
 		http_client := http.Client{Timeout: 30 * time.Second}
 
 		for {
-			item_to_fetch, open := <-chanSampleMetadata
+			worker_handle.state = worker_idle
+			item_to_fetch, open := inputSampleMetadata.Receive()
 			if !open {
-				ack_channel <- true
+				worker_handle.state = worker_done
 				return
 			}
+			worker_handle.state = worker_running
 
 			// Cast the item to fetch to the correct type
 			http_sample, ok := item_to_fetch.(dbSampleMetadata)
@@ -31,21 +30,13 @@ func (b BackendHTTP) collectSamples(chanSampleMetadata chan SampleDataPointers, 
 				panic("Failed to cast the item to fetch to dbSampleMetadata. This worker is probably misconfigured")
 			}
 
-			sample := fetchSample(b.config, &http_client, http_sample, transform, pre_encode_images)
+			sample := fetchSample(b.config, &http_client, http_sample, transform, encodeImages)
 			if sample != nil {
-				chanSamples <- *sample
+				outputSamples.Send(*sample)
 			}
 		}
 	}
 
-	// Start the workers and work on the metadata channel
-	for i := 0; i < b.concurrency; i++ {
-		go sampleWorker()
-	}
-
-	// Wait for all the workers to be done or overall context to be cancelled
-	for i := 0; i < b.concurrency; i++ {
-		<-ack_channel
-	}
-	close(chanSamples)
+	run_worker_pool(sampleWorker, inputSampleMetadata, outputSamples)
+	outputSamples.Close()
 }

--- a/python/benchmark_filesystem.py
+++ b/python/benchmark_filesystem.py
@@ -14,7 +14,6 @@ def benchmark(
     crop_and_resize: bool = typer.Option(
         True, help="Crop and resize the images on the fly"
     ),
-    concurrency: int = typer.Option(64, help="The number of coroutines"),
     compare_torch: bool = typer.Option(True, help="Compare against torch dataloader"),
 ):
     print(f"Running benchmark for {root_path} - {limit} samples")
@@ -34,9 +33,8 @@ def benchmark(
             "max_aspect_ratio": 2.0,
             "pre_encode_images": False,
         },
-        "prefetch_buffer_size": concurrency * 2,
-        "samples_buffer_size": concurrency * 2,
-        "concurrency": concurrency,
+        "prefetch_buffer_size": 128,
+        "samples_buffer_size": 64,
         "limit": limit,
     }
 

--- a/python/dataset.py
+++ b/python/dataset.py
@@ -87,7 +87,6 @@ if __name__ == "__main__":
         },
         "prefetch_buffer_size": 64,
         "samples_buffer_size": 128,
-        "concurrency": 1,
         "limit": 10,
     }
     dataset = DatagoIterDataset(client_config)

--- a/python/test_datago_db.py
+++ b/python/test_datago_db.py
@@ -35,7 +35,6 @@ def get_json_config():
         },
         "prefetch_buffer_size": 64,
         "samples_buffer_size": 128,
-        "concurrency": 1,
         "limit": 10,
     }
     return client_config
@@ -87,9 +86,9 @@ def test_caption_and_image():
         assert (
             go_array_to_pil_image(sample.AdditionalImages["masked_image"]).mode == "RGB"
         ), "Image should be RGB"
-        assert (
-            go_array_to_pil_image(sample.Masks["segmentation_mask"]).mode == "L"
-        ), "Mask should be L"
+        assert go_array_to_pil_image(sample.Masks["segmentation_mask"]).mode == "L", (
+            "Mask should be L"
+        )
 
         if i > N_SAMPLES:
             break
@@ -150,14 +149,14 @@ def no_test_jpg_compression():
     assert (
         go_array_to_pil_image(sample.AdditionalImages["masked_image"]).mode == "RGB"
     ), "Image should be RGB"
-    assert (
-        go_array_to_pil_image(sample.Masks["segmentation_mask"]).mode == "L"
-    ), "Mask should be L"
+    assert go_array_to_pil_image(sample.Masks["segmentation_mask"]).mode == "L", (
+        "Mask should be L"
+    )
 
     # Check the embeddings decoding
-    assert (
-        go_array_to_numpy(sample.CocaEmbedding) is not None
-    ), "Embedding should be set"
+    assert go_array_to_numpy(sample.CocaEmbedding) is not None, (
+        "Embedding should be set"
+    )
 
 
 def test_original_image():
@@ -173,9 +172,9 @@ def test_original_image():
     assert (
         go_array_to_pil_image(sample.AdditionalImages["masked_image"]).mode == "RGB"
     ), "Image should be RGB"
-    assert (
-        go_array_to_pil_image(sample.Masks["segmentation_mask"]).mode == "L"
-    ), "Mask should be L"
+    assert go_array_to_pil_image(sample.Masks["segmentation_mask"]).mode == "L", (
+        "Mask should be L"
+    )
 
 
 def test_duplicate_state():


### PR DESCRIPTION
Removes a manual setting, adjust the size of the worker pool depending on their status (idle or busy) & wait lines on the way in and out. Code is a little ugly, some bits could probably be reverted

Tackles #62, makes the code and lib easier to test and benchmark since ideally you don´t care about the underlying machine 

New record at 1500 samples/second on IN1k, but feels like IO could be improved (io_uring anyone ?)