### PR TITLE
[chore] Build package with 1.22, 1.23 is still slow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.22"
 
       - run: go version
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.22"
 
       - name: Install linux deps
         run: |

--- a/.github/workflows/gopy.yml
+++ b/.github/workflows/gopy.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.22"
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
go 1.22 is tested by gopy, here's to me hoping that it's as fast as 1.18 we were using previously (which is incompatible with the file mmap added recently)