### PR TITLE
Async most of the Rust code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "arbitrary"
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "avif-serialize"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e335041290c43101ca215eed6f43ec437eb5a42125573f600fc3fa42b9bddd62"
+checksum = "98922d6a4cfbcb08820c69d8eeccc05bb1f29bfa06b4f5b1dbfe9a868bd7608e"
 dependencies = [
  "arrayvec",
 ]
@@ -172,9 +172,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bitstream-io"
@@ -184,21 +184,21 @@ checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
 
 [[package]]
 name = "built"
-version = "0.7.5"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c360505aed52b7ec96a3636c3f039d99103c37d1d9b4f7a8c743d3ea9ffcd03b"
+checksum = "56ed6191a7e78c36abdb16ab65341eefd73d64d303fffccdbb00d51e4205967b"
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytemuck"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 
 [[package]]
 name = "byteorder"
@@ -214,15 +214,15 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.10"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
@@ -247,9 +247,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.27"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.27"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
 dependencies = [
  "anstream",
  "anstyle",
@@ -269,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -367,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "csv-core"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
 dependencies = [
  "memchr",
 ]
@@ -428,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -449,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -495,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -591,7 +591,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -612,9 +624,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "h2"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -699,15 +711,15 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.5"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -965,9 +977,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.5"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "interpolate_name"
@@ -1014,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
@@ -1067,15 +1079,15 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b9569d2f74e257076d8c6bfa73fb505b46b851e51ddaecc825944aa3bed17fa"
+checksum = "cf78f52d400cf2d84a3a973a78a592b4adc535739e0a5597a0da6f0c357adc75"
 dependencies = [
  "arbitrary",
  "cc",
@@ -1087,7 +1099,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "libc",
 ]
 
@@ -1099,9 +1111,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lock_api"
@@ -1115,9 +1127,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "loop9"
@@ -1167,9 +1179,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -1182,15 +1194,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "native-tls"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
 dependencies = [
  "libc",
  "log",
@@ -1296,17 +1308,17 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "openssl"
-version = "0.10.69"
+version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e534d133a060a3c19daec1eb3e98ec6f4685978834f2dbadfe2ec215bab64e"
+checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1343,9 +1355,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.104"
+version = "0.9.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
 dependencies = [
  "cc",
  "libc",
@@ -1380,9 +1392,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "png"
@@ -1399,9 +1411,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "ppv-lite86"
@@ -1428,9 +1440,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -1456,9 +1468,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fe09249128b3173d092de9523eaa75136bf7ba85e0d69eca241c7939c933cc"
+checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -1474,9 +1486,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd3927b5a78757a0d71aa9dff669f903b1eb64b54142a9bd9f757f8fde65fd7"
+checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1484,9 +1496,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab6bb2102bd8f991e7749f130a70d05dd557613e39ed2deeee8e9ca0c4d548d"
+checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1494,9 +1506,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91871864b353fd5ffcb3f91f2f703a22a9797c91b9ab497b1acac7b07ae509c7"
+checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1506,9 +1518,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43abc3b80bc20f3facd86cd3c60beed58c3e2aa26213f3cda368de39c60a27e4"
+checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1534,9 +1546,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
 dependencies = [
  "proc-macro2",
 ]
@@ -1568,7 +1580,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -1647,7 +1659,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror",
 ]
@@ -1705,15 +1717,14 @@ checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -1730,7 +1741,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1739,9 +1750,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.21"
+version = "0.23.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
+checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -1761,9 +1772,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 
 [[package]]
 name = "rustls-webpki"
@@ -1778,15 +1789,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -1818,7 +1829,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1837,18 +1848,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1857,9 +1868,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -1920,9 +1931,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "socket2"
@@ -1933,12 +1944,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1960,9 +1965,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1995,7 +2000,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -2031,13 +2036,13 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
  "cfg-if",
  "fastrand",
- "getrandom",
+ "getrandom 0.3.1",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -2116,7 +2121,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2131,9 +2148,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls",
  "tokio",
@@ -2154,9 +2171,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2175,9 +2192,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap",
  "serde",
@@ -2240,9 +2257,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-width"
@@ -2252,9 +2269,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unindent"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "untrusted"
@@ -2338,6 +2355,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2571,11 +2597,20 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.24"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -2637,18 +2672,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,13 @@ serde_json = "1.0"
 url = "2.5.4"
 kanal = "0.1.0-pre8"
 clap = { version = "4.5.27", features = ["derive"] }
-tokio = "1.43.0"
+tokio = { version = "1.43.0", features = ["rt-multi-thread", "macros"] }
 prettytable-rs = "0.10.0"
 pyo3 = { version = "0.23.4", features = ["extension-module"] }
 threadpool = "1.8.1"
-num_cpus = "1.16.0"
 openssl = { version = "0.10", features = ["vendored"] }
 walkdir = "2.5.0"
+num_cpus = "1.16.0"
 
 [profile.release]
 opt-level = 3  # Optimize for speed

--- a/python/benchmark_filesystem.py
+++ b/python/benchmark_filesystem.py
@@ -43,10 +43,13 @@ def benchmark(
     start = time.time()  # Note that the datago dataset will start walking the filesystem at construction time
 
     img = None
+    count = 0
     for sample in tqdm(datago_dataset, dynamic_ncols=True):
         assert sample["id"] != ""
         img = sample["image"]
+        count += 1
 
+    assert count == limit, f"Expected {limit} samples, got {count}"
     fps = limit / (time.time() - start)
     print(f"Datago FPS {fps:.2f}")
     del datago_dataset

--- a/python/dataset.py
+++ b/python/dataset.py
@@ -45,7 +45,7 @@ class DatagoIterDataset:
             raise StopIteration
 
         sample = self.client.get_sample()
-        if sample.id == "":
+        if not sample or sample.id == "":
             raise StopIteration
 
         if self.return_python_types:

--- a/src/generator_files.rs
+++ b/src/generator_files.rs
@@ -44,11 +44,12 @@ pub fn ping_files(
         }
     });
 
-    let page_size = 500;
+    let page_size = 50;
 
-    // While we have something in the Send the samples to the channel
+    // Iterate over the files and send the pages of files as they come
     let mut count = 0;
     let mut filepaths = Vec::new();
+    let max_submitted_samples = (1.1 * (num_samples as f64)).ceil() as usize;
 
     // Build a page from the files iterator
     for entry in files {
@@ -66,7 +67,7 @@ pub fn ping_files(
         filepaths.push(file_name);
         count += 1;
 
-        if filepaths.len() >= page_size || count >= num_samples {
+        if filepaths.len() >= page_size || count >= max_submitted_samples {
             // Convert the page to a JSON
             let page_json = serde_json::json!({
                 "results": filepaths,
@@ -82,7 +83,7 @@ pub fn ping_files(
             filepaths.clear();
         }
 
-        if count >= num_samples {
+        if count >= max_submitted_samples {
             // NOTE: This doesn´t count the samples which have actually been processed
             println!("ping_pages: reached the limit of samples requested. Shutting down");
             break;

--- a/src/generator_http.rs
+++ b/src/generator_http.rs
@@ -163,7 +163,7 @@ pub fn ping_pages(
     source_config: SourceDBConfig,
     rank: usize,
     world_size: usize,
-    num_samples: usize,
+    limit: usize,
 ) {
     let retries = 5;
 
@@ -285,7 +285,8 @@ pub fn ping_pages(
 
     // While we have something in the Send the samples to the channel
     let mut count = 0;
-    while count < num_samples {
+    let max_submitted_samples = (1.1 * (limit as f64)).ceil() as usize;
+    while count < max_submitted_samples {
         // Push the page to the channel
         if pages_tx.send(response_json.clone()).is_err() {
             println!("ping_pages: stream already closed, wrapping up");
@@ -332,7 +333,7 @@ pub fn ping_pages(
     // Either we don't have any more samples or we have reached the limit
     println!(
         "ping_pages: total samples requested: {}. page samples served {}",
-        num_samples, count
+        limit, count
     );
 
     // Send an empty value to signal the end of the stream
@@ -347,11 +348,16 @@ pub fn ping_pages(
 pub fn dispatch_pages(
     pages_rx: kanal::Receiver<serde_json::Value>,
     samples_meta_tx: kanal::Sender<serde_json::Value>,
-    num_samples: usize,
+    limit: usize,
 ) {
-    // While we have something in the Send the samples to the channel
+    // While we have something, send the samples to the channel
     let mut count = 0;
-    while count < num_samples {
+
+    // Send a bit more than the requested samples, in case some are invalid
+    // 10% arbitrary margin, the workers will stop early if not useful
+    let max_submitted_samples = (1.1 * (limit as f64)).ceil() as usize;
+
+    loop {
         match pages_rx.recv() {
             Ok(serde_json::Value::Null) => {
                 println!("dispatch_pages: end of stream received, stopping there");
@@ -372,7 +378,7 @@ pub fn dispatch_pages(
 
                         count += 1;
 
-                        if count >= num_samples {
+                        if count >= max_submitted_samples {
                             // NOTE: This doesn´t count the samples which have actually been processed
                             println!(
                                 "dispatch_pages: reached the limit of samples requested. Shutting down"
@@ -398,7 +404,7 @@ pub fn dispatch_pages(
     // Either we don't have any more samples or we have reached the limit
     println!(
         "dispatch_pages: total samples requested: {}. served {}",
-        num_samples, count
+        limit, count
     );
 
     // Send an empty value to signal the end of the stream

--- a/src/image_processing.rs
+++ b/src/image_processing.rs
@@ -21,7 +21,10 @@ impl ImageTransformConfig {
             self.max_aspect_ratio,
         );
 
-        println!("Target image sizes:\n{:?}\n", target_image_sizes);
+        println!(
+            "Cropping and resizing images. Target image sizes:\n{:?}\n",
+            target_image_sizes
+        );
 
         let mut aspect_ratio_to_size = std::collections::HashMap::new();
         for img_size in &target_image_sizes {
@@ -105,7 +108,7 @@ impl ARAwareTransform {
         }
     }
 
-    pub fn crop_and_resize(
+    pub async fn crop_and_resize(
         &self,
         image: &image::DynamicImage,
         aspect_ratio_input: Option<&String>,
@@ -135,8 +138,8 @@ mod tests {
     use image::DynamicImage;
     use image::GenericImageView;
 
-    #[test]
-    fn test_aspect_ratio_transform() {
+    #[tokio::test]
+    async fn test_aspect_ratio_transform() {
         let config = ImageTransformConfig {
             crop_and_resize: true,
             default_image_size: 224,
@@ -155,15 +158,19 @@ mod tests {
 
         // Test image resizing
         let img = DynamicImage::new_rgb8(300, 200);
-        let resized = transform.crop_and_resize(&img, Some(&"1.000".to_string()));
+        let resized = transform
+            .crop_and_resize(&img, Some(&"1.000".to_string()))
+            .await;
         assert_eq!(resized.dimensions(), (224, 224));
 
-        let resized = transform.crop_and_resize(&img, Some(&"1.900".to_string()));
+        let resized = transform
+            .crop_and_resize(&img, Some(&"1.900".to_string()))
+            .await;
         assert_eq!(resized.dimensions(), (304, 160));
 
         // Test empty aspect ratio input (should use closest)
         let img = DynamicImage::new_rgb8(400, 200);
-        let resized = transform.crop_and_resize(&img, None);
+        let resized = transform.crop_and_resize(&img, None).await;
         assert_eq!(resized.dimensions(), (304, 160));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,6 +161,6 @@ fn main() {
     table.add_row(row!["Total Samples", num_samples]);
     table.add_row(row!["Execution time", format!("{:.2}", elapsed_secs)]);
     table.add_row(row!["Samples / s", format!("{:.2}", fps)]);
-    table.add_row(row!["Active Threads", num_cpus::get()]);
+    table.add_row(row!["Threads", num_cpus::get()]);
     table.printstd();
 }

--- a/src/worker_files.rs
+++ b/src/worker_files.rs
@@ -1,10 +1,10 @@
 use crate::image_processing;
 use crate::structs::{ImagePayload, Sample};
+use std::cmp::min;
 use std::collections::HashMap;
 use std::io::Cursor;
-use std::sync::Arc;
 
-fn image_from_path(path: &str) -> Result<image::DynamicImage, image::ImageError> {
+async fn image_from_path(path: &str) -> Result<image::DynamicImage, image::ImageError> {
     // Load bytes from the file
     let bytes = std::fs::read(path).map_err(|e| {
         image::ImageError::IoError(std::io::Error::new(std::io::ErrorKind::Other, e))
@@ -14,12 +14,12 @@ fn image_from_path(path: &str) -> Result<image::DynamicImage, image::ImageError>
     image::load_from_memory(&bytes)
 }
 
-fn image_payload_from_path(
+async fn image_payload_from_path(
     path: &str,
     img_tfm: &Option<image_processing::ARAwareTransform>,
     encode_images: bool,
 ) -> Result<ImagePayload, image::ImageError> {
-    match image_from_path(path) {
+    match image_from_path(path).await {
         Ok(mut new_image) => {
             let original_height = new_image.height() as usize;
             let original_width = new_image.width() as usize;
@@ -28,7 +28,7 @@ fn image_payload_from_path(
 
             // Optionally transform the additional image in the same way the main image was
             if let Some(img_tfm) = img_tfm {
-                new_image = img_tfm.crop_and_resize(&new_image, None);
+                new_image = img_tfm.crop_and_resize(&new_image, None).await;
             }
 
             let height = new_image.height() as usize;
@@ -66,56 +66,117 @@ fn image_payload_from_path(
     }
 }
 
-fn pull_sample(
-    sample_json: &serde_json::Value,
-    img_tfm: &Option<image_processing::ARAwareTransform>,
+async fn pull_sample(
+    sample_json: serde_json::Value,
+    img_tfm: Option<image_processing::ARAwareTransform>,
     encode_images: bool,
-) -> Option<Sample> {
-    let image_payload =
-        image_payload_from_path(sample_json.as_str().unwrap(), img_tfm, encode_images);
+    samples_tx: kanal::Sender<Sample>,
+) -> Result<(), ()> {
+    match image_payload_from_path(sample_json.as_str().unwrap(), &img_tfm, encode_images).await {
+        Ok(image) => {
+            let sample = Sample {
+                id: sample_json.to_string(),
+                source: "filesystem".to_string(),
+                image,
+                attributes: HashMap::new(),
+                coca_embedding: vec![],
+                tags: vec![],
+                masks: HashMap::new(),
+                latents: HashMap::new(),
+                additional_images: HashMap::new(),
+                duplicate_state: 0,
+            };
 
-    if let Ok(image) = image_payload {
-        Some(Sample {
-            id: sample_json.to_string(),
-            source: "filesystem".to_string(),
-            image,
-            attributes: HashMap::new(),
-            coca_embedding: vec![],
-            tags: vec![],
-            masks: HashMap::new(),
-            latents: HashMap::new(),
-            additional_images: HashMap::new(),
-            duplicate_state: 0,
-        })
-    } else {
-        println!("Failed to load image from path {}", sample_json);
-        None
+            if samples_tx.send(sample).is_err() {
+                // Channel is closed, wrapping up
+                return Err(());
+            }
+            Ok(())
+        }
+        Err(e) => {
+            println!("Failed to load image from path {} {}", sample_json, e);
+            Err(())
+        }
     }
+}
+
+pub async fn consume_oldest_task(
+    tasks: &mut std::collections::VecDeque<tokio::task::JoinHandle<Result<(), ()>>>,
+) -> Result<(), ()> {
+    match tasks.pop_front().unwrap().await {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            println!("worker: sample skipped {}", e);
+            Err(())
+        }
+    }
+}
+
+async fn async_pull_samples(
+    samples_meta_rx: kanal::Receiver<serde_json::Value>,
+    samples_tx: kanal::Sender<Sample>,
+    image_transform: Option<image_processing::ARAwareTransform>,
+    encode_images: bool,
+    limit: usize,
+) {
+    // We use async-await here, to better use IO stalls
+    // We'll issue N async tasks in parallel, and wait for them to finish
+    let max_tasks_per_thread = min(num_cpus::get() * 2, limit);
+    let mut tasks = std::collections::VecDeque::new();
+    let mut count = 0;
+
+    while let Ok(received) = samples_meta_rx.recv() {
+        if received == serde_json::Value::Null {
+            println!("file_worker: end of stream received, stopping there");
+            samples_meta_rx.close();
+            break;
+        }
+
+        // Append a new task to the queue
+        tasks.push_back(tokio::spawn(pull_sample(
+            received,
+            image_transform.clone(),
+            encode_images,
+            samples_tx.clone(),
+        )));
+
+        // If we have enough tasks, we'll wait for the older one to finish
+        if tasks.len() >= max_tasks_per_thread && consume_oldest_task(&mut tasks).await.is_ok() {
+            count += 1;
+        }
+        if count >= limit {
+            break;
+        }
+    }
+
+    // Make sure to wait for all the remaining tasks
+    while !tasks.is_empty() {
+        if consume_oldest_task(&mut tasks).await.is_ok() {
+            count += 1;
+        }
+    }
+    println!("file_worker: total samples sent: {}\n", count);
 }
 
 pub fn pull_samples(
     samples_meta_rx: kanal::Receiver<serde_json::Value>,
     samples_tx: kanal::Sender<Sample>,
-    worker_done_count: Arc<std::sync::atomic::AtomicUsize>,
-    image_transform: &Option<image_processing::ARAwareTransform>,
+    image_transform: Option<image_processing::ARAwareTransform>,
     encode_images: bool,
+    limit: usize,
 ) {
-    while let Ok(received) = samples_meta_rx.recv() {
-        if received == serde_json::Value::Null {
-            println!("http_worker: end of stream received, stopping there");
-            samples_meta_rx.close();
-            break;
-        }
-
-        if let Some(sample) = pull_sample(&received, image_transform, encode_images) {
-            if samples_tx.send(sample).is_err() {
-                println!("http_worker: failed to send a sample");
-                break;
-            }
-        } else {
-            break;
-        }
-    }
-
-    worker_done_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            async_pull_samples(
+                samples_meta_rx,
+                samples_tx,
+                image_transform,
+                encode_images,
+                limit,
+            )
+            .await;
+        });
 }

--- a/src/worker_http.rs
+++ b/src/worker_http.rs
@@ -1,13 +1,14 @@
 use crate::image_processing;
 use crate::structs::{CocaEmbedding, ImagePayload, LatentPayload, Sample, UrlLatent};
 use serde::{Deserialize, Serialize};
+use std::cmp::min;
 use std::io::Cursor;
 use std::sync::Arc;
 
 // We'll share a single connection pool across all worker threads
 #[derive(Clone)]
 pub struct SharedClient {
-    pub client: reqwest::blocking::Client,
+    pub client: reqwest::Client,
     pub semaphore: Arc<tokio::sync::Semaphore>,
 }
 
@@ -24,16 +25,21 @@ struct SampleMetadata {
     coca_embedding: Option<CocaEmbedding>,
 }
 
-fn bytes_from_url(shared_client: &SharedClient, url: &str) -> Option<Vec<u8>> {
+async fn bytes_from_url(shared_client: &SharedClient, url: &str) -> Option<Vec<u8>> {
     // Retry on the request a few times
     let retries = 5;
     let timeout = std::time::Duration::from_secs(30);
     for _ in 0..retries {
         let permit = shared_client.semaphore.acquire();
 
-        if let Ok(response) = shared_client.client.get(url).timeout(timeout).send() {
-            if let Ok(bytes) = response.bytes() {
-                return Some(bytes.to_vec());
+        match shared_client.client.get(url).timeout(timeout).send().await {
+            Ok(response) => {
+                if let Ok(bytes) = response.bytes().await {
+                    return Some(bytes.to_vec());
+                }
+            }
+            Err(e) => {
+                println!("Failed to fetch image bytes: {}", e);
             }
         }
         drop(permit);
@@ -41,14 +47,14 @@ fn bytes_from_url(shared_client: &SharedClient, url: &str) -> Option<Vec<u8>> {
     None
 }
 
-fn image_from_url(
+async fn image_from_url(
     client: &SharedClient,
     url: &str,
 ) -> Result<image::DynamicImage, image::ImageError> {
     // Retry on the fetch and decode a few times, could happen that we get a broken packet
     let retries = 5;
     for _ in 0..retries {
-        if let Some(bytes) = bytes_from_url(client, url) {
+        if let Some(bytes) = bytes_from_url(client, url).await {
             return image::load_from_memory(&bytes);
         }
     }
@@ -58,14 +64,14 @@ fn image_from_url(
     )))
 }
 
-fn image_payload_from_url(
+async fn image_payload_from_url(
     client: &SharedClient,
     url: &str,
     img_tfm: &Option<image_processing::ARAwareTransform>,
     aspect_ratio: &String,
     encode_images: bool,
 ) -> Result<ImagePayload, image::ImageError> {
-    match image_from_url(client, url) {
+    match image_from_url(client, url).await {
         Ok(mut new_image) => {
             let original_height = new_image.height() as usize;
             let original_width = new_image.width() as usize;
@@ -80,7 +86,10 @@ fn image_payload_from_url(
                     Some(aspect_ratio)
                 };
 
-                new_image = img_tfm.crop_and_resize(&new_image, aspect_ratio_input);
+                // TODO: tokio::spawn this
+                new_image = img_tfm
+                    .crop_and_resize(&new_image, aspect_ratio_input)
+                    .await;
             }
 
             let height = new_image.height() as usize;
@@ -118,14 +127,13 @@ fn image_payload_from_url(
     }
 }
 
-fn pull_sample(
-    client: &SharedClient,
+async fn pull_sample(
+    client: SharedClient,
     sample_json: serde_json::Value,
-    img_tfm: &Option<image_processing::ARAwareTransform>,
+    img_tfm: Option<image_processing::ARAwareTransform>,
     encode_images: bool,
-) -> Option<Sample> {
-    // TODO: Make this whole function async
-
+    samples_tx: kanal::Sender<Sample>,
+) -> Result<(), ()> {
     // Deserialize the sample metadata
     let sample: SampleMetadata = serde_json::from_value(sample_json).unwrap(); // Ok to surface an error here, return type will catch it
 
@@ -134,22 +142,28 @@ fn pull_sample(
     let mut aspect_ratio = String::new();
 
     if let Some(image_url) = &sample.image_direct_url {
-        image_payload =
-            match image_payload_from_url(client, image_url, img_tfm, &String::new(), encode_images)
-            {
-                Ok(payload) => {
-                    aspect_ratio = image_processing::aspect_ratio_to_str((
-                        payload.width as i32,
-                        payload.height as i32,
-                    ));
-                    Some(payload)
-                }
-                Err(e) => {
-                    println!("Failed to get image from URL: {}", image_url);
-                    println!("Error: {:?}", e);
-                    return None;
-                }
-            };
+        image_payload = match image_payload_from_url(
+            &client,
+            image_url,
+            &img_tfm,
+            &String::new(),
+            encode_images,
+        )
+        .await
+        {
+            Ok(payload) => {
+                aspect_ratio = image_processing::aspect_ratio_to_str((
+                    payload.width as i32,
+                    payload.height as i32,
+                ));
+                Some(payload)
+            }
+            Err(e) => {
+                println!("Failed to get image from URL: {}", image_url);
+                println!("Error: {:?}", e);
+                return Err(());
+            }
+        };
     }
 
     // Same for the latents, mask and masked images, if they exist
@@ -165,12 +179,14 @@ fn pull_sample(
             if latent.latent_type.contains("image") && !latent.latent_type.contains("latent_") {
                 // Image types, registered as latents but they need to be jpg-decoded
                 match image_payload_from_url(
-                    client,
+                    &client,
                     &latent.file_direct_url,
-                    img_tfm,
+                    &img_tfm,
                     &aspect_ratio,
                     encode_images,
-                ) {
+                )
+                .await
+                {
                     Ok(additional_image_payload) => {
                         additional_images
                             .insert(latent.latent_type.clone(), additional_image_payload);
@@ -181,18 +197,20 @@ fn pull_sample(
                             "Failed to get additional image from URL: {} {} {:?}",
                             latent.latent_type, latent.file_direct_url, e
                         );
-                        return None;
+                        return Err(());
                     }
                 }
             } else if latent.is_mask {
                 // Mask types, registered as latents but they need to be png-decoded
                 match image_payload_from_url(
-                    client,
+                    &client,
                     &latent.file_direct_url,
-                    img_tfm,
+                    &img_tfm,
                     &aspect_ratio,
                     encode_images,
-                ) {
+                )
+                .await
+                {
                     Ok(mask_payload) => {
                         masks.insert(latent.latent_type.clone(), mask_payload);
                     }
@@ -202,12 +220,12 @@ fn pull_sample(
                             "Failed to get mask from URL: {} {} {:?}",
                             latent.latent_type, latent.file_direct_url, e
                         );
-                        return None;
+                        return Err(());
                     }
                 }
             } else {
                 // Vanilla latents, pure binary payloads
-                match bytes_from_url(client, &latent.file_direct_url) {
+                match bytes_from_url(&client, &latent.file_direct_url).await {
                     Some(latent_payload) => {
                         latents.insert(
                             latent.latent_type.clone(),
@@ -219,7 +237,7 @@ fn pull_sample(
                     }
                     None => {
                         println!("Error fetching latent: {}", latent.file_direct_url);
-                        return None;
+                        return Err(());
                     }
                 }
             }
@@ -247,17 +265,26 @@ fn pull_sample(
         coca_embedding: sample.coca_embedding.unwrap_or_default().vector,
         tags: sample.tags.unwrap_or_default(),
     };
-    Some(pulled_sample)
+    if samples_tx.send(pulled_sample).is_err() {
+        // Channel is closed, wrapping up
+        return Err(());
+    }
+    Ok(())
 }
 
-pub fn pull_samples(
+async fn async_pull_samples(
     client: SharedClient,
     samples_meta_rx: kanal::Receiver<serde_json::Value>,
     samples_tx: kanal::Sender<Sample>,
-    worker_done_count: Arc<std::sync::atomic::AtomicUsize>,
-    image_transform: &Option<image_processing::ARAwareTransform>,
+    image_transform: Option<image_processing::ARAwareTransform>,
     encode_images: bool,
+    limit: usize,
 ) {
+    // We use async-await here, to better use IO stalls
+    // We'll keep a pool of N async tasks in parallel
+    let max_tasks_per_thread = min(num_cpus::get() * 2, limit);
+    let mut tasks = std::collections::VecDeque::new();
+    let mut count = 0;
     while let Ok(received) = samples_meta_rx.recv() {
         if received == serde_json::Value::Null {
             println!("http_worker: end of stream received, stopping there");
@@ -265,15 +292,66 @@ pub fn pull_samples(
             break;
         }
 
-        if let Some(sample) = pull_sample(&client, received, image_transform, encode_images) {
-            if samples_tx.send(sample).is_err() {
-                println!("http_worker: failed to send a sample");
-                break;
+        // Append a new task to the queue
+        tasks.push_back(tokio::spawn(pull_sample(
+            client.clone(),
+            received,
+            image_transform.clone(),
+            encode_images,
+            samples_tx.clone(),
+        )));
+
+        // If we have enough tasks, we'll wait for the older one to finish
+        if tasks.len() >= max_tasks_per_thread {
+            match tasks.pop_front().unwrap().await {
+                Ok(_) => {
+                    count += 1;
+                }
+                Err(e) => {
+                    println!("worker: sample skipped {}", e);
+                }
             }
-        } else {
+        }
+        if count >= limit {
             break;
         }
     }
 
-    worker_done_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    // Make sure to wait for all the remaining tasks
+    while !tasks.is_empty() {
+        match tasks.pop_front().unwrap().await {
+            Ok(_) => {
+                count += 1;
+            }
+            Err(e) => {
+                println!("worker: sample skipped {}", e);
+            }
+        }
+    }
+    println!("http_worker: total samples sent: {}\n", count);
+}
+
+pub fn pull_samples(
+    client: SharedClient,
+    samples_meta_rx: kanal::Receiver<serde_json::Value>,
+    samples_tx: kanal::Sender<Sample>,
+    image_transform: Option<image_processing::ARAwareTransform>,
+    encode_images: bool,
+    limit: usize,
+) {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            async_pull_samples(
+                client,
+                samples_meta_rx,
+                samples_tx,
+                image_transform,
+                encode_images,
+                limit,
+            )
+            .await;
+        });
 }

--- a/tests/client_test.rs
+++ b/tests/client_test.rs
@@ -291,7 +291,6 @@ fn test_sources_ne() {
 
         let sample = sample.unwrap();
         assert!(!sample.id.is_empty());
-        println!("{}", sample.source);
         assert!(sample.source == "LAION_AESTHETICS");
     }
 }


### PR DESCRIPTION
- No more threadpool
- Still a mechanism with a number of tasks in flight (implicit threadpool let's say), because we don´t want to materialize all the tasks if there are 2M of them. We materialize a task window which is renewed as the samples are consumed by the user. always wait on the oldest task
- One seperate lane per sample (tokio::spawn), may not be optimal, we could only spawn the CPU heavy work and keep everything else in the main async lane ?

Pretty fast.. 4000 img/s when warm (served from RAM cache) on IN1k on a 2021 laptop (no crop & resize). I never got anything close to this with Go, max 1k

addresses https://github.com/Photoroom/datago/issues/81