### PR TITLE
2025.3.4 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "datago"
-version = "2025.3.3"
+version = "2025.3.4"
 dependencies = [
  "clap",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "datago"
 edition = "2021"
-version = "2025.3.3"
+version = "2025.3.4"
 
 [lib]
 # exposed by pyo3


### PR DESCRIPTION
need to write a better CI/CD.. cargo requires version numbers to be file defined, maturin defines package version via cargo