### PR TITLE
[files] Convenience, enforce randomness

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,10 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
-  - repo: https://github.com/dnephin/pre-commit-golang
-    rev: v0.5.1
+  - repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
     hooks:
-      - id: go-fmt
+      - id: fmt
+      - id: cargo-check
+      - id: clippy
+        args: ["--", "-D", "warnings"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,7 +387,7 @@ dependencies = [
 
 [[package]]
 name = "datago"
-version = "2025.3.8"
+version = "2025.3.9"
 dependencies = [
  "clap",
  "image",
@@ -396,6 +396,7 @@ dependencies = [
  "openssl",
  "prettytable-rs",
  "pyo3",
+ "rand 0.9.0",
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
@@ -1512,7 +1513,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -1651,8 +1652,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+ "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -1662,7 +1674,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1672,6 +1694,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.1",
 ]
 
 [[package]]
@@ -1700,8 +1731,8 @@ dependencies = [
  "once_cell",
  "paste",
  "profiling",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "simd_helpers",
  "system-deps",
  "thiserror",
@@ -1852,7 +1883,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c"
 dependencies = [
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2829,7 +2860,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
+dependencies = [
+ "zerocopy-derive 0.8.23",
 ]
 
 [[package]]
@@ -2837,6 +2877,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "datago"
 edition = "2021"
-version = "2025.3.8"
+version = "2025.3.9"
 
 [lib]
 # exposed by pyo3
@@ -30,6 +30,7 @@ walkdir = "2.5.0"
 num_cpus = "1.16.0"
 reqwest-middleware = "0.4.1"
 reqwest-retry = "0.7.0"
+rand = "0.9.0"
 
 [profile.release]
 opt-level = 3  # Optimize for speed

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ for _ in range(10):
 ```
 
 Please note that the image buffers will be passed around as raw pointers, see below.
-To test datago while serving local files (jpg, png, ..), code would look like the following
+To test datago while serving local files (jpg, png, ..), code would look like the following.
+**Note that datago serving files with a lot of concurrent threads means that, even if random_order is not set,
+there will be some randomness in the sample ordering.**
 
 ```python
 from datago import DatagoClient
@@ -59,6 +61,7 @@ config = {
     "source_type": "file",
     "source_config": {
         "root_path": "myPath",
+        "random_order": False, # True if used directly for training
     },
     "limit": 200,
     "rank": 0,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "datago"
 authors = [
   { name="Photoroom", email="team@photoroom.com" },
 ]
-description = "A high performance dataloader for Python, written in Golang"
+description = "A high performance dataloader for Python, written in Rust"
 readme = "README.md"
 requires-python = ">=3.8"
 classifiers = [

--- a/python/benchmark_filesystem.py
+++ b/python/benchmark_filesystem.py
@@ -18,9 +18,7 @@ def benchmark(
     print(f"Running benchmark for {root_path} - {limit} samples")
     client_config = {
         "source_type": "file",
-        "source_config": {
-            "root_path": root_path,
-        },
+        "source_config": {"root_path": root_path},
         "image_config": {
             "crop_and_resize": crop_and_resize,
             "default_image_size": 1024,

--- a/python/test_datago_filesystem.py
+++ b/python/test_datago_filesystem.py
@@ -6,29 +6,31 @@ import pytest
 import random
 
 
+def generate_tmp_files(dir, limit):
+    for i in range(limit):
+        # Prepare an ephemeral test set
+        mode = "RGB" if random.random() > 0.5 else "RGBA"
+        img = Image.new(mode, (100, 100))
+
+        # Randomly make the image 16 bits
+        if random.random() > 0.5:
+            img = img.convert("I;16")
+
+        img.save(dir + f"/test_{i}.png")
+
+
 @pytest.mark.parametrize("pre_encode_images", [False, True])
 def test_get_sample_filesystem(pre_encode_images: bool):
     limit = 10
 
     with tempfile.TemporaryDirectory() as tmpdirname:
-        cwd = tmpdirname
-
-        for i in range(limit):
-            # Prepare an ephemeral test set
-            mode = "RGB" if random.random() > 0.5 else "RGBA"
-            img = Image.new(mode, (100, 100))
-
-            # Randomly make the image 16 bits
-            if random.random() > 0.5:
-                img = img.convert("I;16")
-
-            img.save(cwd + f"/test_{i}.png")
+        generate_tmp_files(tmpdirname, limit)
 
         # Check that we can instantiate a client and get a sample, nothing more
         client_config = {
             "source_type": "file",
             "source_config": {
-                "root_path": cwd,
+                "root_path": tmpdirname,
             },
             "image_config": {
                 "crop_and_resize": False,
@@ -60,6 +62,53 @@ def test_get_sample_filesystem(pre_encode_images: bool):
                 assert data.image.bit_depth == 8
 
         assert count == limit
+
+
+def test_random_walk():
+    limit = 50
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        generate_tmp_files(tmpdirname, limit)
+
+        # Check that we can instantiate a client and get a sample, nothing more
+        client_config = {
+            "source_type": "file",
+            "source_config": {
+                "root_path": tmpdirname,
+                "random_order": True,
+            },
+            "image_config": {
+                "crop_and_resize": False,
+                "default_image_size": 512,
+                "downsampling_ratio": 16,
+                "min_aspect_ratio": 0.5,
+                "max_aspect_ratio": 2.0,
+                "pre_encode_images": False,
+            },
+            "limit": limit,
+            "prefetch_buffer_size": 64,
+            "samples_buffer_size": 10,
+            "rank": 0,
+            "world_size": 1,
+        }
+
+        results = []
+        n_runs = 3
+        for _ in range(n_runs):
+            client = DatagoClient(json.dumps(client_config))
+            run_results = []
+            for i in range(limit):
+                data = client.get_sample()
+                if not data:
+                    break
+                run_results.append(data.id)
+
+            results.append(run_results)
+
+        # Check that the results are all different
+        for i in range(n_runs):
+            for j in range(i + 1, n_runs):
+                assert results[i] != results[j]
 
 
 if __name__ == "__main__":

--- a/src/generator_http.rs
+++ b/src/generator_http.rs
@@ -390,10 +390,6 @@ pub fn dispatch_pages(
                 break;
             }
             Ok(response_json) => {
-                println!(
-                    "Got a new page to dispatch. Recipient channel current cap: {}",
-                    samples_meta_tx.len()
-                );
                 match response_json.get("results") {
                     Some(results) => {
                         // Go over the samples from the current page

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,11 +145,8 @@ fn main() {
 
         if i % 100 == 0 {
             println!(
-                "{}",
-                format!(
-                    "{i}: Samples/s {:.2}",
-                    100 as f64 / rolling_time.elapsed().as_secs_f64()
-                )
+                "{i}: Samples/s {:.2}",
+                100_f64 / rolling_time.elapsed().as_secs_f64()
             );
             rolling_time = std::time::Instant::now();
         }


### PR DESCRIPTION
Add an option to enforce randomness on the files being served. Note that even without this setting there will be some randomness, as the different threads compete while loading files and will finish at different times. It would not be uniformly random though (which would show in ML while training on possibly big batches), so this is useful