### PR TITLE
[feat] Webdataset support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,184 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b37fc50485c4f3f736a4fb14199f6d5f5ba008d7f28fe710306c92780f004c07"
+dependencies = [
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
+dependencies = [
+ "async-lock",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 0.38.44",
+ "slab",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+dependencies = [
+ "event-listener 5.4.0",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.0",
+ "futures-lite",
+ "rustix 0.38.44",
+ "tracing",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 0.38.44",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "730294c1c08c2e0f85759590518f6333f0d5a0a766a27d519c1b244c3dfd8a24"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-tar"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a42f905d4f623faf634bbd1e001e84e0efc24694afa64be9ad239bf6ca49e1f8"
+dependencies = [
+ "async-std",
+ "filetime",
+ "libc",
+ "pin-project",
+ "redox_syscall 0.2.16",
+ "xattr 0.2.3",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +379,19 @@ name = "bitstream-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
+
+[[package]]
+name = "blocking"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
 
 [[package]]
 name = "built"
@@ -318,6 +509,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,8 +598,12 @@ dependencies = [
 name = "datago"
 version = "2025.5.1"
 dependencies = [
+ "async-compression",
+ "async-tar",
  "clap",
  "env_logger",
+ "flate2",
+ "futures",
  "image",
  "kanal",
  "log",
@@ -413,8 +617,10 @@ dependencies = [
  "reqwest-retry",
  "serde",
  "serde_json",
+ "tar",
  "threadpool",
  "tokio",
+ "tokio-util",
  "url",
  "walkdir",
 ]
@@ -512,6 +718,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.0",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "exr"
 version = "1.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,6 +772,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -630,6 +875,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,6 +968,18 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "h2"
@@ -1190,6 +1460,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1225,7 +1504,14 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.9.0",
  "libc",
+ "redox_syscall 0.5.11",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1254,6 +1540,9 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "loop9"
@@ -1491,6 +1780,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1510,7 +1805,7 @@ dependencies = [
  "cfg-if",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "winapi",
 ]
@@ -1528,6 +1823,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1538,6 +1853,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "pkg-config"
@@ -1556,6 +1882,21 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi 0.4.0",
+ "pin-project-lite",
+ "rustix 0.38.44",
+ "tracing",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1851,6 +2192,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+dependencies = [
+ "bitflags 2.9.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2011,6 +2361,19 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
@@ -2018,8 +2381,8 @@ dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys 0.52.0",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2183,6 +2546,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2306,6 +2678,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr 1.5.0",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2326,8 +2709,8 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
- "rustix",
- "windows-sys 0.52.0",
+ "rustix 1.0.7",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2446,6 +2829,7 @@ checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -2612,6 +2996,12 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "value-bag"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
 
 [[package]]
 name = "vcpkg"
@@ -3015,6 +3405,25 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "xattr"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
+dependencies = [
+ "libc",
+ "rustix 1.0.7",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,6 +394,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bracoxide"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3572b24445a122332bb25a2637248d62ca8b567351d98b1194ca4132c61810bd"
+
+[[package]]
 name = "built"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,6 +606,7 @@ version = "2025.5.1"
 dependencies = [
  "async-compression",
  "async-tar",
+ "bracoxide",
  "clap",
  "env_logger",
  "flate2",
@@ -714,7 +721,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2369,7 +2376,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "datago"
-version = "2025.5.1"
+version = "2025.6.1"
 dependencies = [
  "async-compression",
  "async-tar",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,9 +1293,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.5"
+version = "0.25.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd6f44aed642f18953a158afeb30206f4d50da59fbc66ecb53c66488de73563b"
+checksum = "db35664ce6b9810857a38a906215e75a9c879f0696556a39f59c62829710251a"
 dependencies = [
  "bytemuck",
  "byteorder-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,12 @@ reqwest-retry = "0.7.0"
 rand = "0.9.0"
 log = "0.4.27"
 env_logger = "0.11.8"
+tar = "0.4.44"
+futures = "0.3.31"
+flate2 = "1.1.1"
+async-tar = "0.5.0"
+tokio-util = { version = "0.7.15", features = ["io", "compat"] } # Add "compat"
+async-compression = {version= "0.4.23", features=["tokio"]}
 
 [profile.release]
 opt-level = 3  # Optimize for speed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "datago"
 edition = "2021"
-version = "2025.5.1"
+version = "2025.6.1"
 
 [lib]
 # exposed by pyo3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ flate2 = "1.1.1"
 async-tar = "0.5.0"
 tokio-util = { version = "0.7.15", features = ["io", "compat"] } # Add "compat"
 async-compression = {version= "0.4.23", features=["tokio"]}
+bracoxide = "0.1.6"
 
 [profile.release]
 opt-level = 3  # Optimize for speed

--- a/README.md
+++ b/README.md
@@ -93,6 +93,53 @@ for _ in range(10):
     sample = client.get_sample()
 ```
 
+</details><details> <summary><strong>[experimental] Webdataset</strong></summary>
+
+Please note that this implementation is very new, and probably has significant limitations still. It has not yet been tested at scale.
+
+```python
+from datago import DatagoClient, initialize_logging
+import os
+import json
+
+# Can also set the log level directly instead of using RUST_LOG env var
+initialize_logging(log_level="warn")
+
+# URL of the test bucket
+bucket = "https://storage.googleapis.com/webdataset/fake-imagenet"
+dataset = "/imagenet-train-{000000..001281}.tar"
+url = bucket + dataset
+
+print(f"Running benchmark for {limit} samples")
+client_config = {
+    "source_type": "webdataset",
+    "source_config": {
+        "url": url,
+        "random_sampling": False,
+        "max_tasks_in_flight": 16 # The number of tarballs which should be handled concurrently
+        "rank": 0,
+        "world_size": 1,
+    },
+    # Optional pre-processing of the images, placing them in an aspect ratio bucket to preseve as much as possible of the original content
+    "image_config": {
+        "crop_and_resize": crop_and_resize,
+        "default_image_size": 1024,
+        "downsampling_ratio": 32,
+        "min_aspect_ratio": 0.5,
+        "max_aspect_ratio": 2.0,
+        "pre_encode_images": False,
+    },
+    "prefetch_buffer_size": 128,
+    "samples_buffer_size": 64,
+    "limit": limit,
+}
+
+client = DatagoClient(json.dumps(config))
+
+for _ in range(10):
+    sample = client.get_sample()
+```
+
 </details>
 
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ client_config = {
     "source_config": {
         "url": url,
         "random_sampling": False,
-        "max_tasks_in_flight": 16 # The number of tarballs which should be handled concurrently
+        "max_tasks_in_flight": 16 # The number of TarballSamples which should be handled concurrently
         "rank": 0,
         "world_size": 1,
     },

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ config = {
     "source_config": {
         "sources": os.environ.get("DATAROOM_TEST_SOURCE", ""),
         "page_size": 500,
+        "rank": 0,
+        "world_size": 1,
     },
     "limit": 200,
-    "rank": 0,
-    "world_size": 1,
     "samples_buffer_size": 32,
 }
 

--- a/python/benchmark_filesystem.py
+++ b/python/benchmark_filesystem.py
@@ -64,7 +64,7 @@ def benchmark(
 
     # Let's compare against a classic pytorch dataloader
     if compare_torch:
-        from torchvision import datasets, transforms
+        from torchvision import datasets, transforms  # type: ignore
         from torch.utils.data import DataLoader
 
         print("Benchmarking torch dataloader")

--- a/python/benchmark_filesystem.py
+++ b/python/benchmark_filesystem.py
@@ -100,7 +100,7 @@ def benchmark(
         # Iterate over the DataLoader
         start = time.time()
         n_images = 0
-        for batch in dataloader:
+        for batch in tqdm(dataloader, dynamic_ncols=True):
             n_images += len(batch)
             if n_images > limit:
                 break

--- a/python/benchmark_webdataset.py
+++ b/python/benchmark_webdataset.py
@@ -1,0 +1,122 @@
+import time
+from tqdm import tqdm
+import typer
+from dataset import DatagoIterDataset
+import os
+
+
+def benchmark(
+    limit: int = typer.Option(2000, help="The number of samples to test on"),
+    crop_and_resize: bool = typer.Option(True, help="Crop and resize the images on the fly"),
+    compare_wds: bool = typer.Option(True, help="Compare against torch dataloader"),
+):
+    # URL of the test bucket
+    # bucket = "https://storage.googleapis.com/webdataset/fake-imagenet"
+    # dataset = "/imagenet-train-{000000..001281}.tar"
+
+    bucket = "https://huggingface.co/datasets/sayakpaul/pd12m-full/resolve/"
+    dataset = "main/{00155..02480}.tar"
+
+    url = bucket + dataset
+
+    print(f"Benchmarking Datago WDS path on {url}.\nRunning benchmark for {limit} samples")
+    client_config = {
+        "source_type": "webdataset",
+        "source_config": {
+            "url": url,
+            "shuffle": True,
+            "max_concurrency": 8,  # Number of concurrent tarball downloads and dispatch
+            "auth_token": os.environ.get("HF_TOKEN", default=""),
+        },
+        "image_config": {
+            "crop_and_resize": crop_and_resize,
+            "default_image_size": 1024,
+            "downsampling_ratio": 32,
+            "min_aspect_ratio": 0.5,
+            "max_aspect_ratio": 2.0,
+            "pre_encode_images": False,
+        },
+        "prefetch_buffer_size": 256,
+        "samples_buffer_size": 256,
+        "limit": limit,
+        "rank": 0,
+        "world_size": 1,
+    }
+
+    # # Make sure in the following that we compare apples to apples, meaning in that case
+    # # that we materialize the payloads in the python scope in the expected format
+    # # (PIL.Image for images and masks for instance, numpy arrays for latents)
+    datago_dataset = DatagoIterDataset(client_config, return_python_types=True)
+    start = time.time()  # Note that the datago dataset will start walking the filesystem at construction time
+
+    img, count = None, 0
+    for sample in tqdm(datago_dataset, dynamic_ncols=True):
+        assert sample["id"] != ""
+        img = sample["image"]
+        count += 1
+
+    assert count == limit, f"Expected {limit} samples, got {count}"
+    fps = limit / (time.time() - start)
+    print(f"-- Datago WDS FPS {fps:.2f}")
+    del datago_dataset
+
+    # Save the last image as a test
+    assert img is not None, "No image - benchmark did not run"
+    img.save("benchmark_last_image.png")
+
+    # Let's compare against a classic webdataset dataloader
+    if compare_wds:
+        from torchvision import transforms
+        from torch.utils.data import DataLoader
+        import webdataset as wds
+
+        print("\nBenchmarking webdataset library dataloader")
+        # Define the transformations to apply to each image
+        transform = (
+            transforms.Compose(
+                [
+                    transforms.Resize((1024, 1024), interpolation=transforms.InterpolationMode.LANCZOS),
+                ]
+            )
+            if crop_and_resize
+            else None
+        )
+
+        def custom_transform(sample):
+            if "jpg" in sample:
+                sample["jpg"] = transform(sample["jpg"])
+            if "png" in sample:
+                sample["png"] = transform(sample["png"])
+            return sample
+
+        # Create a WebDataset instance
+        dataset = (
+            wds.WebDataset(url, shardshuffle=False)
+            .shuffle(1000)  # Optional: shuffle with buffer
+            .decode("pil")  # Decode images using PIL
+            .map(custom_transform)
+            # .to_tuple("png", "cls")  # Map keys to output tuple
+        )
+
+        n_processes = 16  # Change to use whatever feels right for your machine
+        dataloader = DataLoader(
+            dataset,
+            batch_size=1,
+            num_workers=n_processes,
+            prefetch_factor=2,
+            collate_fn=lambda x: x,
+        )
+
+        # Iterate over the DataLoader
+        start = time.time()
+        n_images = 0
+        for _ in dataloader:
+            n_images += 1
+            if n_images > limit:
+                break
+        fps = n_images / (time.time() - start)
+        print(f"-- Webdataset lib FPS ({n_processes} processes) {fps:.2f}")
+
+
+if __name__ == "__main__":
+    typer.run(benchmark)

--- a/python/benchmark_webdataset.py
+++ b/python/benchmark_webdataset.py
@@ -32,7 +32,7 @@ def benchmark(
         "source_config": {
             "url": url,
             "shuffle": True,
-            "max_concurrency": 2,  # Number of concurrent tarball downloads and dispatch
+            "max_concurrency": 2,  # Number of concurrent TarballSample downloads and dispatch
             "auth_token": os.environ.get("HF_TOKEN", default=""),
         },
         "image_config": {

--- a/src/client.rs
+++ b/src/client.rs
@@ -294,6 +294,9 @@ mod tests {
     }
 
     #[cfg(test)]
+    use log::debug;
+
+    #[cfg(test)]
     fn check_image(img: &ImagePayload) {
         assert!(!img.data.is_empty());
 
@@ -480,7 +483,7 @@ mod tests {
         let sample = sample.unwrap();
         assert!(!sample.id.is_empty());
         // Check that sample.tags does not contain any of the tags in the tags string
-        println!("{:?}", sample.tags);
+        debug!("{:?}", sample.tags);
         for tag in tags.split(',') {
             assert!(!sample.tags.contains(&tag.to_string()));
         }
@@ -581,7 +584,7 @@ mod tests {
 
             let sample = sample.unwrap();
             assert!(!sample.id.is_empty());
-            println!("{}", sample.source);
+            debug!("{}", sample.source);
             assert!(sources.contains(&sample.source.as_str()));
         }
     }
@@ -594,7 +597,7 @@ mod tests {
         config["source_config"]["sources_ne"] = "LAION_ART".into();
         config["limit"] = json!(limit);
 
-        println!("{}", config);
+        debug!("{}", config);
         let mut client = DatagoClient::new(config.to_string());
 
         for _ in 0..limit {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,6 @@
 use crate::generator_files;
 use crate::generator_http;
+use crate::generator_wds;
 use crate::image_processing::ARAwareTransform;
 use crate::structs::{DatagoClientConfig, Sample, SourceType};
 
@@ -79,6 +80,10 @@ impl DatagoClient {
             }
             SourceType::File => {
                 self.engine = Some(generator_files::orchestrate(self));
+            }
+            SourceType::WebDataset => {
+                warn!("WebDataset source type is new and experimental, use with caution!\nPlease report any issues you encounter to https://github.com/Photoroom/datago/issues.");
+                self.engine = Some(generator_wds::orchestrate(self));
             }
         }
 

--- a/src/generator_files.rs
+++ b/src/generator_files.rs
@@ -11,10 +11,13 @@ use std::thread;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SourceFileConfig {
     pub root_path: String,
+
     #[serde(default)]
     pub random_sampling: bool,
+
     #[serde(default)]
     pub rank: usize,
+
     #[serde(default)]
     pub world_size: usize,
 }
@@ -57,7 +60,7 @@ fn enumerate_files(
         })
         .collect();
 
-    // If random_sampling is set, shuffle the files
+    // If shuffle is set, shuffle the files
     let files_iter = if source_config.random_sampling {
         let mut rng = rand::rng(); // Falls back to OsRng, which will differ over time
         files_list.shuffle(&mut rng);

--- a/src/generator_wds.rs
+++ b/src/generator_wds.rs
@@ -1,0 +1,632 @@
+use crate::client::DatagoClient;
+use crate::structs::{new_shared_client, DatagoEngine, SharedClient, TarballContent, WDSContent};
+use crate::worker_wds;
+
+use async_tar::Archive;
+use kanal::bounded;
+use log::{debug, info, warn};
+use rand::seq::SliceRandom;
+use reqwest::Url;
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::thread;
+
+use futures::AsyncReadExt;
+use futures::StreamExt;
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::path::Path;
+use tokio::io::BufReader;
+use tokio_util::compat::TokioAsyncReadCompatExt;
+use tokio_util::io::StreamReader; // For grouping, if more complex grouping is needed
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SourceWebDatasetConfig {
+    pub url: String,
+
+    #[serde(default)]
+    pub random_sampling: bool,
+
+    #[serde(default)]
+    pub max_concurrency: usize,
+
+    #[serde(default)]
+    pub auth_token: String,
+
+    #[serde(default)]
+    pub rank: usize,
+
+    #[serde(default)]
+    pub world_size: usize,
+}
+
+fn urls_from_pattern(url: &str) -> Vec<String> {
+    // Extract the pattern within curly braces
+    let pattern = url.split('{').nth(1).unwrap_or("");
+    let pattern = pattern.split('}').next().unwrap_or("");
+
+    // Split the pattern into parts
+    let parts: Vec<&str> = pattern.split("..").collect();
+    let start = parts[0].parse::<i32>().unwrap_or(0);
+    let end = parts[1].parse::<i32>().unwrap_or(0);
+    assert!(end >= start, "End must be greater than start");
+    assert!(
+        parts[0].len() == parts[1].len(),
+        "Couldn't make sense of the URL pattern provided"
+    );
+
+    // Generate all the URLs, note that not all patterns will have the same number of digits
+    let digit_count = parts[0].len();
+    (start..=end)
+        .map(|i| {
+            url.replace(
+                &format!("{{{}}}", pattern),
+                &format!("{:0width$}", i, width = digit_count),
+            )
+        })
+        .collect()
+}
+
+fn hash_fn(key: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    key.hash(&mut hasher);
+    hasher.finish()
+}
+
+async fn pull_tarball(
+    shared_client: Arc<SharedClient>,
+    url: serde_json::Value,
+    samples_metadata_tx: kanal::Sender<TarballContent>,
+    config: SourceWebDatasetConfig,
+) -> Result<(), String> {
+    // Given the url to a given tarball, we'll download it and submit the samples on the fly to the worker pool
+    debug!(
+        "dispatch_shards: downloading a new tarball {:?}",
+        url.as_str()
+    );
+
+    let auth_token = if config.auth_token.is_empty() {
+        None
+    } else {
+        Some(config.auth_token.as_str())
+    };
+    let url = url.as_str().unwrap();
+
+    // We use a shared client to make it possible to limit the number of outstanding connections
+    let _permit = shared_client.semaphore.acquire();
+    let mut request_builder = shared_client.client.get(url);
+    if let Some(token) = auth_token {
+        request_builder = request_builder.bearer_auth(token);
+    }
+
+    // Grab an async byte stream from the request, we'll try to untar the results on the fly
+    let response = request_builder.send().await;
+    if response.is_err() {
+        return Err("Failed to send request".into());
+    }
+    let response = response.unwrap();
+    if !response.status().is_success() {
+        return Err(format!("Failed to download tarball: {}", response.status()));
+    }
+
+    let byte_stream = response.bytes_stream();
+
+    // Convert the byte stream to an AsyncRead
+    let stream_reader =
+        StreamReader::new(byte_stream.map(|res_bytes| {
+            res_bytes.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+        }));
+
+    // Wrap in BufReader for the async Tar reader
+    let buf_reader = BufReader::new(stream_reader);
+
+    // Create a tar archive reader from the decompressed stream
+    let archive = Archive::new(buf_reader.compat());
+
+    let mut entries = archive
+        .entries()
+        .map_err(|e| format!("Failed to fetch tarball: {}", e))?; // This returns a stream
+
+    let mut current_sample_key: Option<String> = None;
+    let mut current_files_for_sample: TarballContent = Vec::new();
+
+    while let Some(entry_result) = entries.next().await {
+        let mut entry = entry_result.map_err(|e| format!("Failed to read tarball entry: {}", e))?;
+
+        let header_path = entry
+            .path()
+            .map_err(|e| format!("Error considering tarball content {}", e))?
+            .into_owned();
+        let filename = header_path.to_string_lossy().into_owned();
+
+        // Simple key extraction: basename without extension
+        let entry_key = Path::new(&filename)
+            .file_stem()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned();
+
+        // If we have a > 1 world size, we need to dispatch the samples to the correct rank
+        // We'll do this by hashing the key and checking if it matches our rank, we skip otherwise
+        if config.world_size > 1 {
+            let hash = hash_fn(&entry_key);
+            let target_rank = (hash % config.world_size as u64) as usize;
+            if target_rank != config.rank {
+                continue;
+            }
+        }
+
+        // If the key changes, the previous sample is complete
+        if current_sample_key.is_none() {
+            current_sample_key = Some(entry_key.clone());
+        }
+        if current_sample_key.as_ref() != Some(&entry_key) && !current_files_for_sample.is_empty() {
+            if samples_metadata_tx.send(current_files_for_sample).is_err() {
+                debug!("dispatch_shards (streaming): samples_metadata_tx channel closed.");
+                return Err("Channel closed".into());
+            }
+            current_files_for_sample = Vec::new();
+            current_sample_key = Some(entry_key.clone());
+        }
+
+        let mut buffer = Vec::new();
+        entry
+            .read_to_end(&mut buffer)
+            .await
+            .map_err(|e| format!("Failed to read tarball {}", e))?; // Read the content of the current file
+
+        current_files_for_sample.push(WDSContent { filename, buffer });
+        debug!(
+            "dispatch_shards (streaming): processed entry {:?}, key: {:?}",
+            Path::new(&current_files_for_sample.last().unwrap().filename)
+                .file_name()
+                .unwrap_or_default(),
+            entry_key
+        );
+    }
+    // Send the last collected sample if any
+    if !current_files_for_sample.is_empty()
+        && samples_metadata_tx.send(current_files_for_sample).is_err()
+    {
+        debug!("dispatch_shards (streaming): samples_metadata_tx channel closed for last sample.");
+        return Err("Channel closed".into());
+    }
+
+    debug!(
+        "dispatch_shards (streaming): finished processing tarball {}",
+        url
+    );
+    Ok(())
+}
+
+async fn pull_tarball_task(
+    shared_client: Arc<SharedClient>,
+    url: serde_json::Value,
+    samples_metadata_tx: kanal::Sender<TarballContent>,
+    config: SourceWebDatasetConfig,
+) -> Result<(), String> {
+    let retries = 3;
+    let mut attempt = 0;
+    let mut success = false;
+
+    while attempt < retries && !success {
+        match pull_tarball(
+            shared_client.clone(),
+            url.clone(),
+            samples_metadata_tx.clone(),
+            config.clone(),
+        )
+        .await
+        {
+            Ok(_) => {
+                success = true;
+            }
+            Err(e) => {
+                attempt += 1;
+                debug!(
+                    "Error pulling tarball: {}. Attempt {}/{}",
+                    e, attempt, retries
+                );
+            }
+        }
+    }
+    if !success {
+        return Err(format!("Failed to pull tarball after {} attempts", retries));
+    }
+    debug!("dispatch_shards: finished pulling tarball");
+    Ok(())
+}
+
+async fn get_url_list(
+    shared_client: &Arc<SharedClient>,
+    config: &SourceWebDatasetConfig,
+) -> Result<Vec<serde_json::Value>, String> {
+    let _permit = shared_client.semaphore.acquire();
+
+    // Either ping the url to get the pages, or use the {...} syntax
+    if config.url.contains("{") {
+        // URL should look like this:
+        // https://storage.googleapis.com/webdataset/testdata/publaynet-train-{000000..000009}.tar
+        // We need to parse the URL and generate all the possible URLs
+        // for instance https://storage.googleapis.com/webdataset/testdata/publaynet-train-000000.tar
+
+        // Extract the pattern within curly braces
+        let urls = urls_from_pattern(&config.url);
+
+        Ok(urls
+            .iter()
+            .map(|url| serde_json::Value::String(url.clone()))
+            .collect())
+    } else {
+        assert!(config.url.contains("https://storage.googleapis.com/"));
+
+        // Given the url, list all the available webdataset files
+        let request = reqwest::Request::new(
+            reqwest::Method::GET,
+            Url::parse(&config.url).map_err(|e| format!("Failed parsing url: {}", e))?,
+        );
+
+        let response = shared_client
+            .client
+            .execute(request)
+            .await
+            .map_err(|e| format!("Failed parsing reply: {}", e))?;
+
+        let response_text = response
+            .text()
+            .await
+            .map_err(|e| format!("Failed parsing reply: {}", e))?;
+        let response_json: serde_json::Value =
+            serde_json::from_str(&response_text).unwrap_or(serde_json::Value::Null);
+
+        // Parse all the "items" in the response
+        if let Some(items) = response_json.get("items") {
+            Ok(items
+                .as_array()
+                .unwrap()
+                .iter()
+                .filter_map(|item| item.get("mediaLink").cloned())
+                .collect())
+        } else {
+            // If the response is empty, return an empty vector
+            warn!("dispatch_shards: no items found in the response");
+            Err("dispatch_shards: no items found in the response".into())
+        }
+    }
+}
+
+async fn tasks_from_shards(
+    shared_client: Arc<SharedClient>,
+    samples_metadata_tx: kanal::Sender<TarballContent>,
+    config: &SourceWebDatasetConfig,
+) -> Result<serde_json::Value, ()> {
+    match get_url_list(&shared_client, config).await {
+        Ok(mut task_list) => {
+            // Shuffle the items if needed
+            if config.random_sampling {
+                task_list.shuffle(&mut rand::rng());
+            }
+
+            // Now submit all the tasks, making sure that too many of them are not in flight
+            let mut tasks = VecDeque::new();
+            let response_json = serde_json::Value::Null;
+            let mut count = 0;
+
+            for url in task_list {
+                tasks.push_back(tokio::spawn(pull_tarball_task(
+                    shared_client.clone(),
+                    url,
+                    samples_metadata_tx.clone(),
+                    config.clone(),
+                )));
+
+                // Some bookkeeping, to limit the number of tasks in flight
+                // we'll wait for the first one to finish before adding a new one
+                if tasks.len() >= config.max_concurrency {
+                    // Catch an early stop in this case, can be that the stream is closed
+                    // and we don't want to keep going forever
+                    let res = tasks.pop_front().unwrap().await;
+                    debug!(
+                        "dispatch_shards: waiting for a task to finish. Got {:?}",
+                        res
+                    );
+                    // Note that the double check is needed, as the task can fail the spawn or return an error
+                    if res.is_err() || res.unwrap().is_err() {
+                        debug!("dispatch_shards: task failed, stopping there");
+                        break;
+                    }
+                }
+
+                count += 1;
+            }
+
+            // Consume all the remaining tasks
+            while !tasks.is_empty() {
+                let _ = tasks.pop_front().unwrap().await;
+            }
+
+            // Bookkeeping and report
+            if count == 0 {
+                warn!("No items found in the response");
+            }
+            debug!("Served {} items from the bucket", count);
+
+            // Send an empty value to signal the end of the stream
+            if samples_metadata_tx.send(vec![]).is_err() {
+                debug!("list_shards: stream already closed, wrapping up");
+            }
+
+            Ok(response_json)
+        }
+        Err(e) => {
+            warn!("Failed to get URL list: {}", e);
+            Err(())
+        }
+    }
+}
+
+fn query_shards_and_dispatch(
+    shared_client: Arc<SharedClient>,
+    samples_metadata_tx: kanal::Sender<TarballContent>,
+    source_config: SourceWebDatasetConfig,
+) {
+    // List all the shards from the bucket
+    // for each of them, start an async task to download the tarball
+    // and unpack it in memory
+    // Then, for each sample in the tarball, send it to the channel
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(source_config.max_concurrency)
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            let _ =
+                tasks_from_shards(shared_client.clone(), samples_metadata_tx, &source_config).await;
+            // FIXME: handle errors
+        });
+}
+
+// ---- Global orchestration ---------
+pub fn orchestrate(client: &DatagoClient) -> DatagoEngine {
+    // Allocate all the message passing pipes
+    let (samples_metadata_tx, samples_metadata_rx) = bounded::<TarballContent>(32);
+    let (samples_tx, samples_rx) = bounded(client.samples_buffer);
+
+    info!("Using webdataset as source");
+
+    // Convert the source_config to a SourceWebDatasetConfig
+    let mut source_config: SourceWebDatasetConfig =
+        serde_json::from_value(client.source_config.clone()).unwrap();
+
+    if source_config.max_concurrency == 0 {
+        info!("WDS: Defaulting to 8 max_concurrency");
+        source_config.max_concurrency = 8;
+    }
+
+    // List the contents of the bucket and feed the workers
+    let http_client = Arc::new(new_shared_client(client.max_connections));
+
+    let feeder = Some(thread::spawn(move || {
+        query_shards_and_dispatch(http_client, samples_metadata_tx, source_config);
+    }));
+
+    // Kick the workers which deserialize all the payloads
+    let image_transform = client.image_transform.clone();
+    let encode_images = client.encode_images;
+    let img_to_rgb8 = client.image_to_rgb8;
+    let limit = client.limit;
+    let samples_tx_worker = samples_tx.clone();
+    let worker = Some(thread::spawn(move || {
+        worker_wds::deserialize_samples(
+            samples_metadata_rx,
+            samples_tx_worker,
+            image_transform,
+            encode_images,
+            img_to_rgb8,
+            limit,
+        );
+    }));
+
+    DatagoEngine {
+        samples_rx,
+        feeder,
+        worker,
+    }
+}
+
+// -------- Unit tests --------
+
+mod tests {
+    #[allow(unused_imports)]
+    use super::*;
+
+    #[test]
+    fn test_urls_from_pattern() {
+        let url = "https://storage.googleapis.com/webdataset/testdata/publaynet-train-{000000..000009}.tar";
+        let urls = urls_from_pattern(url);
+        print!("URLs: {:?}", urls.clone());
+        assert_eq!(urls.len(), 10);
+        assert_eq!(
+            urls[0],
+            "https://storage.googleapis.com/webdataset/testdata/publaynet-train-000000.tar"
+        );
+        assert_eq!(
+            urls[9],
+            "https://storage.googleapis.com/webdataset/testdata/publaynet-train-000009.tar"
+        );
+    }
+
+    #[test]
+    fn test_webdataset_dispatch() {
+        let random_sampling = [false, true];
+
+        for s in random_sampling {
+            let config = SourceWebDatasetConfig {
+                url:
+                    "https://storage.googleapis.com/storage/v1/b/webdataset/o?prefix=fake-imagenet/"
+                        .into(),
+                auth_token: "".into(),
+                random_sampling: s,
+                max_concurrency: 2,
+                rank: 0,
+                world_size: 1,
+            };
+
+            // Query the bucket, pull the workload
+            let http_client = Arc::new(new_shared_client(2));
+            let (samples_meta_tx, samples_meta_rx) = bounded::<TarballContent>(2);
+
+            let mut count = 0;
+            let limit = 2;
+            let feeder = thread::spawn(move || {
+                query_shards_and_dispatch(http_client, samples_meta_tx, config);
+            });
+
+            while count < limit {
+                if let Ok(sample) = samples_meta_rx.recv() {
+                    count += 1;
+
+                    // Check that we got something
+                    assert!(!sample.is_empty(), "Sample is empty");
+                    for s in sample.iter() {
+                        assert!(!s.filename.is_empty(), "Filename is empty");
+                        assert!(!s.buffer.is_empty(), "Buffer is empty");
+                    }
+                } else {
+                    debug!("No more items to receive");
+                    break;
+                }
+            }
+
+            debug!("Received {} items", count);
+            let _ = samples_meta_rx.close();
+            feeder.join().expect("Feeder thread panicked");
+
+            assert!(count >= limit, "Not enough items found in the bucket");
+        }
+    }
+
+    #[cfg(test)]
+    use crate::structs::Sample;
+
+    #[cfg(test)]
+    use serde_json::json;
+    #[test]
+    fn test_webdataset_orchestrate() {
+        fn get_samples(do_random_sampling: bool, n_samples: usize) -> Vec<Sample> {
+            let client_config = json!({
+                "source_config": {
+                    "url": "https://storage.googleapis.com/storage/v1/b/webdataset/o?prefix=fake-imagenet/",
+                    "random_sampling": do_random_sampling,
+                    "max_concurrency": 2
+                },
+                "limit": n_samples,
+                "num_threads": 1,
+                "max_connections": 1,
+                "samples_buffer_size": 1
+            });
+
+            let mut client = DatagoClient::new(client_config.to_string());
+            let engine = orchestrate(&client);
+            let mut count = 0;
+            let limit: i32 = 2;
+
+            let mut samples = Vec::new();
+
+            while let Ok(sample) = engine.samples_rx.recv() {
+                assert!(sample.is_some(), "Sample is None");
+                let sample = sample.unwrap();
+                assert!(!sample.image.data.is_empty(), "Image data is empty");
+                assert!(sample.image.original_height > 0, "Original height is 0");
+                assert!(sample.image.original_width > 0, "Original width is 0");
+                assert!(sample.image.height > 0, "Height is 0");
+                assert!(sample.image.width > 0, "Width is 0");
+                assert!(sample.image.channels > 0, "Channels is 0");
+                assert!(sample.image.bit_depth > 0, "Bit depth is 0");
+                count += 1;
+                samples.push(sample);
+                if count >= limit {
+                    break;
+                }
+            }
+            info!("Received {} items", count);
+            assert!(count >= limit, "Not enough items found in the bucket");
+            client.stop();
+
+            samples
+        }
+
+        let random_sampling = [false, true];
+        for s in random_sampling {
+            let samples_1 = get_samples(s, 10);
+            let samples_2 = get_samples(s, 10);
+            assert_eq!(samples_1.len(), samples_2.len(), "Samples length mismatch");
+
+            if s {
+                let sample_ids_1 = samples_1.iter().map(|s| s.id.clone()).collect::<Vec<_>>();
+                let sample_ids_2 = samples_2.iter().map(|s| s.id.clone()).collect::<Vec<_>>();
+                assert_ne!(
+                    sample_ids_1, sample_ids_2,
+                    "Samples should not be in the same order"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_webdataset_ranks() {
+        fn get_samples(rank: usize, world_size: usize, n_samples: usize) -> Vec<Sample> {
+            let client_config = json!({
+                "source_config": {
+                    "url": "https://storage.googleapis.com/storage/v1/b/webdataset/o?prefix=fake-imagenet/",
+                    "random_sampling": false,
+                    "max_concurrency": 2,
+                    "rank": rank,
+                    "world_size": world_size,
+                },
+                "limit": n_samples,
+
+                "num_threads": 1,
+                "max_connections": 1,
+                "samples_buffer_size": 1
+            });
+
+            let mut client = DatagoClient::new(client_config.to_string());
+            let engine = orchestrate(&client);
+            let mut count = 0;
+
+            let mut samples = Vec::new();
+
+            while let Ok(sample) = engine.samples_rx.recv() {
+                assert!(sample.is_some(), "Sample is None");
+
+                count += 1;
+                samples.push(sample.unwrap());
+                if count >= n_samples {
+                    break;
+                }
+            }
+            info!("Received {} items", count);
+            client.stop();
+
+            samples
+        }
+
+        let samples_1 = get_samples(0, 2, 20);
+        let samples_2 = get_samples(1, 2, 20);
+        assert_eq!(samples_1.len(), samples_2.len(), "Samples length mismatch");
+
+        // Check that the samples are all different, as per a set
+        let sample_ids_1 = samples_1.iter().map(|s| s.id.clone()).collect::<Vec<_>>();
+        let sample_ids_2 = samples_2.iter().map(|s| s.id.clone()).collect::<Vec<_>>();
+        let mut all_samples = sample_ids_1.clone();
+        all_samples.extend(sample_ids_2.clone());
+        all_samples.sort();
+        all_samples.dedup();
+        assert_eq!(
+            all_samples.len(),
+            sample_ids_1.len() + sample_ids_2.len(),
+            "Samples should all be different"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,13 @@
 pub mod client;
 pub mod generator_files;
 pub mod generator_http;
+pub mod generator_wds;
 
 pub mod image_processing;
 pub mod structs;
 pub mod worker_files;
 pub mod worker_http;
+pub mod worker_wds;
 
 pub use client::{initialize_logging, DatagoClient};
 pub use generator_files::SourceFileConfig;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,11 +6,13 @@ use std::collections::HashMap;
 mod client;
 mod generator_files;
 mod generator_http;
+mod generator_wds;
 
 mod image_processing;
 mod structs;
 mod worker_files;
 mod worker_http;
+mod worker_wds;
 
 fn main() {
     client::initialize_logging(Some("info".to_string()));

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -145,9 +145,33 @@ pub fn new_shared_client(max_connections: usize) -> SharedClient {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct WDSContent {
+pub struct BinaryFile {
     pub filename: String,
     pub buffer: Vec<u8>,
 }
 
-pub type TarballContent = Vec<WDSContent>;
+pub struct TarballSample {
+    pub name: String,
+    pub content: Vec<BinaryFile>,
+}
+
+impl TarballSample {
+    pub fn is_empty(&self) -> bool {
+        self.content.is_empty()
+    }
+
+    pub fn add(&mut self, file: BinaryFile) {
+        self.content.push(file);
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &BinaryFile> {
+        self.content.iter()
+    }
+
+    pub fn new(name: String) -> Self {
+        TarballSample {
+            name,
+            content: Vec::new(),
+        }
+    }
+}

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -12,6 +12,7 @@ use std::thread;
 pub enum SourceType {
     Db,
     File,
+    WebDataset,
 }
 
 fn default_source_type() -> SourceType {
@@ -142,3 +143,11 @@ pub fn new_shared_client(max_connections: usize) -> SharedClient {
         semaphore: Arc::new(tokio::sync::Semaphore::new(max_connections)),
     }
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WDSContent {
+    pub filename: String,
+    pub buffer: Vec<u8>,
+}
+
+pub type TarballContent = Vec<WDSContent>;

--- a/src/worker_wds.rs
+++ b/src/worker_wds.rs
@@ -1,20 +1,18 @@
 use crate::image_processing;
 use crate::structs::{ImagePayload, Sample, TarballContent};
-use crate::worker_files::consume_oldest_task;
 use log::{debug, info, warn};
 use std::cmp::min;
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::Arc;
 
 // List all the types we'll support
 pub const TEXT_TYPES: [&str; 3] = ["cls", "json", "txt"];
 pub const IMG_TYPES: [&str; 3] = ["jpg", "jpeg", "png"];
 
-fn extension(filename: &str) -> Option<&str> {
-    filename.split('.').last()
-}
-fn is_supported_type(filename: &str) -> bool {
-    let ext = extension(filename).unwrap_or("");
+fn is_supported_type(ext: &str) -> bool {
+    let lowered_ext = ext.to_lowercase(); // Garding against case sensitivity
+    let ext = lowered_ext.as_str();
     TEXT_TYPES.contains(&ext) || IMG_TYPES.contains(&ext)
 }
 
@@ -26,86 +24,88 @@ async fn pull_sample(
     samples_tx: Arc<kanal::Sender<Option<Sample>>>,
 ) -> Result<(), ()> {
     if !sample.is_empty() {
-        let sample_id = sample[0].filename.split(".").next().unwrap_or("");
+        match Path::new(&sample[0].filename).file_stem() {
+            Some(sample_id) => {
+                let mut attributes = HashMap::new();
+                let mut image = ImagePayload {
+                    data: vec![],
+                    width: 0,
+                    height: 0,
+                    original_height: 0,
+                    original_width: 0,
+                    bit_depth: 0,
+                    channels: 0,
+                };
 
-        let mut attributes = HashMap::new();
-        let mut image = ImagePayload {
-            data: vec![],
-            width: 0,
-            height: 0,
-            original_height: 0,
-            original_width: 0,
-            bit_depth: 0,
-            channels: 0,
-        };
+                for item in sample.iter() {
+                    let ext = Path::new(&item.filename)
+                        .extension()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or("");
 
-        for item in sample.iter() {
-            if !is_supported_type(&item.filename) {
-                debug!("wds_worker: unsupported file type: {}", item.filename);
-            } else {
-                let ext = extension(&item.filename).unwrap_or("");
-
-                if IMG_TYPES.contains(&ext) {
-                    // Load the image in to a buffer
-                    match image::load_from_memory(&item.buffer) {
-                        Ok(raw_image) => {
-                            image = image_processing::image_to_payload(
-                                raw_image,
-                                &img_tfm,
-                                &"".to_string(),
-                                encode_images,
-                                img_to_rgb8,
-                            )
-                            .await
-                            .unwrap_or_else(|_| ImagePayload {
-                                data: vec![],
-                                width: 0,
-                                height: 0,
-                                original_height: 0,
-                                original_width: 0,
-                                bit_depth: 0,
-                                channels: 0,
-                            });
-                            debug!("wds_worker: unpacked {}", item.filename);
+                    if !is_supported_type(ext) {
+                        debug!("wds_worker: unsupported file type: {}", item.filename);
+                    } else if IMG_TYPES.contains(&ext) {
+                        // Load the image in to a buffer
+                        match image::load_from_memory(&item.buffer) {
+                            Ok(raw_image) => {
+                                image = image_processing::image_to_payload(
+                                    raw_image,
+                                    &img_tfm,
+                                    &"".to_string(),
+                                    encode_images,
+                                    img_to_rgb8,
+                                )
+                                .await
+                                .unwrap_or_else(|_| ImagePayload {
+                                    data: vec![],
+                                    width: 0,
+                                    height: 0,
+                                    original_height: 0,
+                                    original_width: 0,
+                                    bit_depth: 0,
+                                    channels: 0,
+                                });
+                                debug!("wds_worker: unpacked {}", item.filename);
+                            }
+                            Err(e) => {
+                                debug!("wds_worker: error loading image: {}", e);
+                                continue;
+                            }
                         }
-                        Err(e) => {
-                            debug!("wds_worker: error loading image: {}", e);
-                            continue;
-                        }
+                    } else if TEXT_TYPES.contains(&ext) {
+                        // Load the file in to a string
+                        let class_file = String::from_utf8_lossy(&item.buffer).to_string();
+                        attributes.insert(ext.to_string(), serde_json::json!(class_file));
+                        debug!("wds_worker: unpacked {}", item.filename);
                     }
-                } else if TEXT_TYPES.contains(&ext) {
-                    // Load the file in to a string
-                    let class_file = String::from_utf8_lossy(&item.buffer).to_string();
-                    attributes.insert(ext.to_string(), serde_json::json!(class_file));
-                    debug!("wds_worker: unpacked {}", item.filename);
-                } else {
-                    debug!(
-                        "wds_worker: supported file type: {} - needs unpacking",
-                        item.filename
-                    );
                 }
+
+                if samples_tx
+                    .send(Some(Sample {
+                        id: String::from(sample_id.to_str().unwrap_or("unkonwn")),
+                        source: "webdataset".to_string(), // FIXME - pass the archive name
+                        image,
+                        attributes,
+                        coca_embedding: vec![],
+                        tags: vec![],
+                        masks: HashMap::new(),
+                        latents: HashMap::new(),
+                        additional_images: HashMap::new(),
+                        duplicate_state: 0,
+                    }))
+                    .is_err()
+                {
+                    debug!("wds_worker: stream already closed, wrapping up");
+                    return Err(());
+                }
+                return Ok(());
+            }
+            None => {
+                debug!("wds_worker: unpacking sample with no ID");
+                return Err(());
             }
         }
-
-        if samples_tx
-            .send(Some(Sample {
-                id: sample_id.to_string(),
-                source: "webdataset".to_string(), // FIXME - pass the archive name
-                image,
-                attributes,
-                coca_embedding: vec![],
-                tags: vec![],
-                masks: HashMap::new(),
-                latents: HashMap::new(),
-                additional_images: HashMap::new(),
-                duplicate_state: 0,
-            }))
-            .is_err()
-        {
-            debug!("wds_worker: stream already closed, wrapping up");
-            return Err(());
-        }
-        return Ok(());
     }
 
     Err(())
@@ -123,7 +123,7 @@ async fn async_deserialize_samples(
     // We'll keep a pool of N async tasks in parallel
     let max_tasks = min(num_cpus::get(), limit);
     info!("Using {} tasks in the async threadpool", max_tasks);
-    let mut tasks = std::collections::VecDeque::new();
+    let mut tasks = tokio::task::JoinSet::new();
     let mut count = 0;
     let shareable_channel_tx: Arc<kanal::Sender<Option<Sample>>> = Arc::new(samples_tx);
     let shareable_img_tfm = Arc::new(image_transform);
@@ -136,35 +136,40 @@ async fn async_deserialize_samples(
         }
 
         // Append a new task to the queue
-        tasks.push_back(tokio::spawn(pull_sample(
+        tasks.spawn(pull_sample(
             sample,
             shareable_img_tfm.clone(),
             encode_images,
             img_to_rgb8,
             shareable_channel_tx.clone(),
-        )));
+        ));
 
         // If we have enough tasks, we'll wait for the older one to finish
         if tasks.len() >= max_tasks {
-            if consume_oldest_task(&mut tasks).await.is_ok() {
+            if tasks.join_next().await.unwrap().is_ok() {
                 count += 1;
             } else {
                 warn!("wds_worker: task failed, stopping there");
                 let _ = samples_metadata_rx.close(); // Stop upstream thread
                 break;
             }
-        }
-        if count >= limit {
-            break;
+
+            if count >= limit {
+                break;
+            }
         }
     }
 
     // Make sure to wait for all the remaining tasks
-    while !tasks.is_empty() {
-        if consume_oldest_task(&mut tasks).await.is_ok() {
+    let _ = tasks.join_all().await.iter().map(|result| {
+        if let Ok(()) = result {
             count += 1;
+        } else {
+            // Task failed or was cancelled
+            debug!("file_worker: task failed or was cancelled");
         }
-    }
+    });
+
     info!("wds_worker: total samples sent: {}\n", count);
 
     // Signal the end of the stream

--- a/src/worker_wds.rs
+++ b/src/worker_wds.rs
@@ -138,7 +138,7 @@ async fn async_deserialize_samples(
     img_to_rgb8: bool,
     limit: usize,
     extension_reference_image: String,
-) -> Result<(), ()> {
+) -> Result<(), String> {
     // We use async-await here, to better use IO stalls
     // We'll keep a pool of N async tasks in parallel
     let max_tasks = min(num_cpus::get(), limit);
@@ -210,7 +210,7 @@ async fn async_deserialize_samples(
             "wds_worker: encountered an error while processing samples: {}",
             error
         );
-        return Err(());
+        return Err(error);
     }
     Ok(())
 }

--- a/src/worker_wds.rs
+++ b/src/worker_wds.rs
@@ -1,0 +1,198 @@
+use crate::image_processing;
+use crate::structs::{ImagePayload, Sample, TarballContent};
+use crate::worker_files::consume_oldest_task;
+use log::{debug, info, warn};
+use std::cmp::min;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+// List all the types we'll support
+pub const TEXT_TYPES: [&str; 3] = ["cls", "json", "txt"];
+pub const IMG_TYPES: [&str; 3] = ["jpg", "jpeg", "png"];
+
+fn extension(filename: &str) -> Option<&str> {
+    filename.split('.').last()
+}
+fn is_supported_type(filename: &str) -> bool {
+    let ext = extension(filename).unwrap_or("");
+    TEXT_TYPES.contains(&ext) || IMG_TYPES.contains(&ext)
+}
+
+async fn pull_sample(
+    sample: TarballContent,
+    img_tfm: Arc<Option<image_processing::ARAwareTransform>>,
+    encode_images: bool,
+    img_to_rgb8: bool,
+    samples_tx: Arc<kanal::Sender<Option<Sample>>>,
+) -> Result<(), ()> {
+    if !sample.is_empty() {
+        let sample_id = sample[0].filename.split(".").next().unwrap_or("");
+
+        let mut attributes = HashMap::new();
+        let mut image = ImagePayload {
+            data: vec![],
+            width: 0,
+            height: 0,
+            original_height: 0,
+            original_width: 0,
+            bit_depth: 0,
+            channels: 0,
+        };
+
+        for item in sample.iter() {
+            if !is_supported_type(&item.filename) {
+                debug!("wds_worker: unsupported file type: {}", item.filename);
+            } else {
+                let ext = extension(&item.filename).unwrap_or("");
+
+                if IMG_TYPES.contains(&ext) {
+                    // Load the image in to a buffer
+                    match image::load_from_memory(&item.buffer) {
+                        Ok(raw_image) => {
+                            image = image_processing::image_to_payload(
+                                raw_image,
+                                &img_tfm,
+                                &"".to_string(),
+                                encode_images,
+                                img_to_rgb8,
+                            )
+                            .await
+                            .unwrap_or_else(|_| ImagePayload {
+                                data: vec![],
+                                width: 0,
+                                height: 0,
+                                original_height: 0,
+                                original_width: 0,
+                                bit_depth: 0,
+                                channels: 0,
+                            });
+                            debug!("wds_worker: unpacked {}", item.filename);
+                        }
+                        Err(e) => {
+                            debug!("wds_worker: error loading image: {}", e);
+                            continue;
+                        }
+                    }
+                } else if TEXT_TYPES.contains(&ext) {
+                    // Load the file in to a string
+                    let class_file = String::from_utf8_lossy(&item.buffer).to_string();
+                    attributes.insert(ext.to_string(), serde_json::json!(class_file));
+                    debug!("wds_worker: unpacked {}", item.filename);
+                } else {
+                    debug!(
+                        "wds_worker: supported file type: {} - needs unpacking",
+                        item.filename
+                    );
+                }
+            }
+        }
+
+        if samples_tx
+            .send(Some(Sample {
+                id: sample_id.to_string(),
+                source: "webdataset".to_string(), // FIXME - pass the archive name
+                image,
+                attributes,
+                coca_embedding: vec![],
+                tags: vec![],
+                masks: HashMap::new(),
+                latents: HashMap::new(),
+                additional_images: HashMap::new(),
+                duplicate_state: 0,
+            }))
+            .is_err()
+        {
+            debug!("wds_worker: stream already closed, wrapping up");
+            return Err(());
+        }
+        return Ok(());
+    }
+
+    Err(())
+}
+
+async fn async_deserialize_samples(
+    samples_metadata_rx: kanal::Receiver<TarballContent>,
+    samples_tx: kanal::Sender<Option<Sample>>,
+    image_transform: Option<image_processing::ARAwareTransform>,
+    encode_images: bool,
+    img_to_rgb8: bool,
+    limit: usize,
+) {
+    // We use async-await here, to better use IO stalls
+    // We'll keep a pool of N async tasks in parallel
+    let max_tasks = min(num_cpus::get(), limit);
+    info!("Using {} tasks in the async threadpool", max_tasks);
+    let mut tasks = std::collections::VecDeque::new();
+    let mut count = 0;
+    let shareable_channel_tx: Arc<kanal::Sender<Option<Sample>>> = Arc::new(samples_tx);
+    let shareable_img_tfm = Arc::new(image_transform);
+
+    while let Ok(sample) = samples_metadata_rx.recv() {
+        if sample.is_empty() {
+            warn!("wds_worker: end of stream received, stopping there");
+            let _ = samples_metadata_rx.close();
+            break;
+        }
+
+        // Append a new task to the queue
+        tasks.push_back(tokio::spawn(pull_sample(
+            sample,
+            shareable_img_tfm.clone(),
+            encode_images,
+            img_to_rgb8,
+            shareable_channel_tx.clone(),
+        )));
+
+        // If we have enough tasks, we'll wait for the older one to finish
+        if tasks.len() >= max_tasks {
+            if consume_oldest_task(&mut tasks).await.is_ok() {
+                count += 1;
+            } else {
+                warn!("wds_worker: task failed, stopping there");
+                let _ = samples_metadata_rx.close(); // Stop upstream thread
+                break;
+            }
+        }
+        if count >= limit {
+            break;
+        }
+    }
+
+    // Make sure to wait for all the remaining tasks
+    while !tasks.is_empty() {
+        if consume_oldest_task(&mut tasks).await.is_ok() {
+            count += 1;
+        }
+    }
+    info!("wds_worker: total samples sent: {}\n", count);
+
+    // Signal the end of the stream
+    if shareable_channel_tx.send(None).is_ok() {} // Channel could have been closed by a .stop() call
+}
+
+pub fn deserialize_samples(
+    samples_metadata_rx: kanal::Receiver<TarballContent>,
+    samples_tx: kanal::Sender<Option<Sample>>,
+    image_transform: Option<image_processing::ARAwareTransform>,
+    encode_images: bool,
+    img_to_rgb8: bool,
+    limit: usize,
+) {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(num_cpus::get())
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            async_deserialize_samples(
+                samples_metadata_rx,
+                samples_tx,
+                image_transform,
+                encode_images,
+                img_to_rgb8,
+                limit,
+            )
+            .await;
+        });
+}


### PR DESCRIPTION
cc @photoroman for early visibility

- [x] New Webdataset head
- [x] Python demo, benchmark 
- [x] multithread bit of a mess, could just use tokio more
- [x] perf optim, probably way too many copies at the moment.
- [x] implement shuffling, buffer and shards wise probably
- [x] missing unit tests left and right
- [x] Expose max download concurrency 
- [x] Dispatch tarball contents on the fly, instead of waiting for the full buffer. Great test set with[ PD12M](https://huggingface.co/datasets/Spawning/PD12M) (11GB shards)
- [x] Graciously handle paths which require authentication / tokens (ie: HF for instance). If not provided then stop instead of trying to pull all payloads one by one
- [x] Support rank and worldsize
- [x] Expose the image key on which to align all image payloads, if any


![datago](https://github.com/user-attachments/assets/2277afcb-8abf-4d17-b2db-dae27c6056d0)
