### PR TITLE
Use log library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "aligned-vec"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,11 +396,13 @@ dependencies = [
 
 [[package]]
 name = "datago"
-version = "2025.4.1"
+version = "2025.4.5"
 dependencies = [
  "clap",
+ "env_logger",
  "image",
  "kanal",
+ "log",
  "num_cpus",
  "openssl",
  "prettytable-rs",
@@ -459,6 +470,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -1098,6 +1132,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jiff"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a064218214dc6a10fbae5ec5fa888d80c45d611aba169222fc272072bf7aef6"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199b7932d97e325aff3a7030e141eafe7f2c6268e1d1b24859b753a627f45254"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1194,9 +1252,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "loop9"
@@ -1508,6 +1566,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1794,6 +1861,35 @@ dependencies = [
  "libredox",
  "thiserror",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "datago"
 edition = "2021"
-version = "2025.4.3"
+version = "2025.4.5"
 
 [lib]
 # exposed by pyo3
@@ -31,6 +31,8 @@ num_cpus = "1.16.0"
 reqwest-middleware = "0.4.1"
 reqwest-retry = "0.7.0"
 rand = "0.9.0"
+log = "0.4.27"
+env_logger = "0.11.8"
 
 [profile.release]
 opt-level = 3  # Optimize for speed

--- a/README.md
+++ b/README.md
@@ -26,9 +26,13 @@ Using Python 3.11, you can simply install datago with `pip install datago`
 ## Use the package from Python
 
 ```python
-from datago import DatagoClient
+from datago import DatagoClient, initialize_logging
 import os
 import json
+
+# Respects RUST_LOG=INFO env var for setting log level
+# If omitted the logger will be initialized when the client starts.
+initialize_logging()
 
 config = {
     "source_config": {
@@ -53,9 +57,12 @@ To test datago while serving local files (jpg, png, ..), code would look like th
 there will be some randomness in the sample ordering.**
 
 ```python
-from datago import DatagoClient
+from datago import DatagoClient, initialize_logging
 import os
 import json
+
+# Can also set the log level directly instead of using RUST_LOG env var
+initialize_logging(log_level="warn")
 
 config = {
     "source_type": "file",
@@ -79,6 +86,12 @@ for _ in range(10):
 ## Match the raw exported buffers with typical python types
 
 See helper functions provided in `raw_types.py`, should be self explanatory. Check python benchmarks for examples.
+
+## Logging
+We are using the [log](https://docs.rs/log/latest/log/) crate with [env_logger](https://docs.rs/env_logger/latest/env_logger/).
+You can set the log level using the RUST_LOG environment variable. E.g. `RUST_LOG=INFO`.
+
+When using the library from Python, `env_logger` will be initialized automatically when creating a `DatagoClient`. There is also a `initialize_logging` function in the `datago` module, which if called before using a client, allows to customize the log level. This only works if RUST_LOG is not set.
 
 </details><details> <summary><strong>Build it</strong></summary>
 
@@ -104,7 +117,7 @@ rustflags = [
 ```
 
 ## Build a benchmark CLI
-`cargo run --release --  -h` to get all the information, should be fairly straightforward
+`Cargo run --release --  -h` to get all the information, should be fairly straightforward
 
 ## Run the rust test suite
 

--- a/python/dataset.py
+++ b/python/dataset.py
@@ -1,4 +1,4 @@
-from datago import DatagoClient
+from datago import DatagoClient, initialize_logging
 import json
 from typing import Dict, Any
 from raw_types import raw_array_to_pil_image, raw_array_to_numpy
@@ -62,6 +62,7 @@ class DatagoIterDataset:
 
 
 if __name__ == "__main__":
+    initialize_logging("warn")
     # Example config, using this for filesystem walkthrough would work just as well
     client_config = client_config = {
         "source_type": "db",

--- a/src/client.rs
+++ b/src/client.rs
@@ -6,6 +6,7 @@ use crate::worker_files;
 use crate::worker_http;
 
 use kanal::bounded;
+use log::{error, info, warn};
 use pyo3::prelude::*;
 use std::sync::Arc;
 use std::thread;
@@ -93,6 +94,10 @@ impl DatagoClient {
             return;
         }
 
+        // In Python, by default the log level is set to "warn", so we do the same here
+        // This has no effect, in case the user has previously called initialize_logging().
+        initialize_logging(Some("warn".to_string()));
+
         // Spawn a new thread which will query the DB and send the pages
         let pages_tx = self.pages_tx.clone();
         let limit = self.limit;
@@ -112,7 +117,7 @@ impl DatagoClient {
                 let source_db_config: generator_http::SourceDBConfig =
                     serde_json::from_value(self.source_config.clone()).unwrap();
 
-                println!("Using DB as source");
+                info!("Using DB as source");
                 let http_client = http_client.clone();
 
                 self.pinger = Some(thread::spawn(move || {
@@ -131,7 +136,7 @@ impl DatagoClient {
                 let source_file_config: generator_files::SourceFileConfig =
                     serde_json::from_value(self.source_config.clone()).unwrap();
 
-                println!("Using file as source {}", source_file_config.root_path);
+                info!("Using file as source {}", source_file_config.root_path);
 
                 self.pinger = Some(thread::spawn(move || {
                     generator_files::ping_files(
@@ -201,7 +206,7 @@ impl DatagoClient {
 
         // If no more samples and workers are closed, then wrap it up
         if self.samples_rx.is_closed() {
-            println!("No more samples to process, stopping the client");
+            info!("No more samples to process, stopping the client");
             self.stop();
             return None;
         }
@@ -215,13 +220,13 @@ impl DatagoClient {
             Ok(sample) => match sample {
                 Some(sample) => Some(sample),
                 None => {
-                    println!("End of stream received, stopping the client");
+                    info!("End of stream received, stopping the client");
                     self.stop();
                     None
                 }
             },
             Err(e) => {
-                println!("Timeout waiting for sample, stopping the client. {}", e);
+                warn!("Timeout waiting for sample, stopping the client. {}", e);
                 self.stop();
                 None
             }
@@ -239,19 +244,19 @@ impl DatagoClient {
 
         if let Some(pinger) = self.pinger.take() {
             if pinger.join().is_err() {
-                println!("Failed to join pinger thread");
+                error!("Failed to join pinger thread");
             }
         }
 
         if let Some(feeder) = self.feeder.take() {
             if feeder.join().is_err() {
-                println!("Failed to join feeder thread");
+                error!("Failed to join feeder thread");
             }
         }
 
         if let Some(worker) = self.worker.take() {
             if worker.join().is_err() {
-                println!("Failed to join worker thread");
+                error!("Failed to join worker thread");
             }
         }
         self.is_started = false;
@@ -262,5 +267,17 @@ impl DatagoClient {
 impl Drop for DatagoClient {
     fn drop(&mut self) {
         self.stop();
+    }
+}
+
+#[pyfunction(signature = (log_level=None))]
+pub fn initialize_logging(log_level: Option<String>) -> bool {
+    // Try to initialize logging, return false if it fails, e.g. if this function is called multiple times.
+    if let Some(level) = log_level {
+        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(level))
+            .try_init()
+            .is_ok()
+    } else {
+        env_logger::try_init().is_ok()
     }
 }

--- a/src/generator_files.rs
+++ b/src/generator_files.rs
@@ -1,3 +1,4 @@
+use log::debug;
 use rand::seq::SliceRandom;
 use serde::{Deserialize, Serialize};
 use std::cmp::min;
@@ -101,13 +102,13 @@ pub fn ping_files(
 
         if count >= max_submitted_samples {
             // NOTE: This doesn´t count the samples which have actually been processed
-            println!("ping_pages: reached the limit of samples requested. Shutting down");
+            debug!("ping_pages: reached the limit of samples requested. Shutting down");
             break;
         }
     }
 
     // Either we don't have any more samples or we have reached the limit
-    println!(
+    debug!(
         "ping_pages: total samples requested: {}. page samples served {}",
         limit, count
     );
@@ -116,7 +117,7 @@ pub fn ping_files(
     match pages_tx.send(serde_json::Value::Null) {
         Ok(_) => {}
         Err(_) => {
-            println!("ping_pages: stream already closed, all good");
+            debug!("ping_pages: stream already closed, all good");
         }
     };
 }

--- a/src/image_processing.rs
+++ b/src/image_processing.rs
@@ -1,5 +1,6 @@
 use crate::structs::ImagePayload;
 use image::ImageEncoder;
+use log::debug;
 use serde::Deserialize;
 use serde::Serialize;
 use std::io::Cursor;
@@ -29,7 +30,7 @@ impl ImageTransformConfig {
             self.max_aspect_ratio,
         );
 
-        println!(
+        debug!(
             "Cropping and resizing images. Target image sizes:\n{:?}\n",
             target_image_sizes
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ pub mod structs;
 pub mod worker_files;
 pub mod worker_http;
 
-pub use client::DatagoClient;
+pub use client::{initialize_logging, DatagoClient};
 pub use generator_files::SourceFileConfig;
 pub use generator_http::SourceDBConfig;
 pub use image_processing::ImageTransformConfig;
@@ -17,5 +17,6 @@ use pyo3::prelude::*;
 #[pymodule]
 fn datago(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<DatagoClient>()?;
+    m.add_function(wrap_pyfunction!(initialize_logging, m)?)?;
     Ok(())
 }

--- a/src/worker_files.rs
+++ b/src/worker_files.rs
@@ -1,5 +1,6 @@
 use crate::image_processing;
 use crate::structs::{ImagePayload, Sample};
+use log::{debug, error, warn};
 use std::cmp::min;
 use std::collections::HashMap;
 use std::collections::VecDeque;
@@ -72,7 +73,7 @@ async fn pull_sample(
             Ok(())
         }
         Err(e) => {
-            println!("Failed to load image from path {} {}", sample_json, e);
+            error!("Failed to load image from path {} {}", sample_json, e);
             Err(())
         }
     }
@@ -84,7 +85,7 @@ pub async fn consume_oldest_task(
     match tasks.pop_front().unwrap().await {
         Ok(_) => Ok(()),
         Err(e) => {
-            println!("worker: sample skipped {}", e);
+            warn!("worker: sample skipped {}", e);
             Err(())
         }
     }
@@ -107,7 +108,7 @@ async fn async_pull_samples(
 
     while let Ok(received) = samples_meta_rx.recv() {
         if received == serde_json::Value::Null {
-            println!("file_worker: end of stream received, stopping there");
+            debug!("file_worker: end of stream received, stopping there");
             let _ = samples_meta_rx.close();
             break;
         }
@@ -136,7 +137,7 @@ async fn async_pull_samples(
             count += 1;
         }
     }
-    println!("file_worker: total samples sent: {}\n", count);
+    debug!("file_worker: total samples sent: {}\n", count);
 
     // Signal the end of the stream
     if samples_tx.send(None).is_ok() {};


### PR DESCRIPTION
- Replace all printf calls with log calls.
- Expose a init_logging function to Python, which takes a log level as string or relies on RUST_LOG env var by default.

Resolves #109