### PR TITLE
[refactor] Simpler setup for files, same would probably work for the DB path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "datago"
-version = "2025.4.5"
+version = "2025.5.1"
 dependencies = [
  "clap",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "datago"
 edition = "2021"
-version = "2025.4.5"
+version = "2025.5.1"
 
 [lib]
 # exposed by pyo3

--- a/README.md
+++ b/README.md
@@ -21,9 +21,21 @@ Depending on the front ends, datago can be rank and world-size aware, in which c
 
 <details> <summary><strong>Use it</strong></summary>
 
-Using Python 3.11, you can simply install datago with `pip install datago`
+You can simply install datago with `[uv] pip install datago`
 
 ## Use the package from Python
+
+Please note that in all the of the following cases, you can directly get an IterableDataset (torch compatible) with the following code snippet
+
+```python
+from dataset import DatagoIterDataset
+client_config = {} # See below for examples
+datago_dataset = DatagoIterDataset(client_config, return_python_types=True)
+```
+
+`return_python_types` enforces that images will be of the PIL.Image sort for instance, being an external binary module should be transparent.
+
+<details> <summary><strong>Dataroom</strong></summary>
 
 ```python
 from datago import DatagoClient, initialize_logging
@@ -51,7 +63,10 @@ for _ in range(10):
     sample = client.get_sample()
 ```
 
-Please note that the image buffers will be passed around as raw pointers, see below.
+Please note that the image buffers will be passed around as raw pointers, see below (we provide python utils to convert to PIL types).
+
+</details><details> <summary><strong>Local files</strong></summary>
+
 To test datago while serving local files (jpg, png, ..), code would look like the following.
 **Note that datago serving files with a lot of concurrent threads means that, even if random_order is not set,
 there will be some randomness in the sample ordering.**
@@ -82,10 +97,12 @@ for _ in range(10):
     sample = client.get_sample()
 ```
 
+</details>
+
 
 ## Match the raw exported buffers with typical python types
 
-See helper functions provided in `raw_types.py`, should be self explanatory. Check python benchmarks for examples.
+See helper functions provided in `raw_types.py`, should be self explanatory. Check python benchmarks for examples. As mentioned above, we also provide a wrapper so that you get a `dataset` directly.
 
 ## Logging
 We are using the [log](https://docs.rs/log/latest/log/) crate with [env_logger](https://docs.rs/env_logger/latest/env_logger/).

--- a/python/benchmark_filesystem.py
+++ b/python/benchmark_filesystem.py
@@ -11,11 +11,15 @@ def benchmark(
     ),
     limit: int = typer.Option(2000, help="The number of samples to test on"),
     crop_and_resize: bool = typer.Option(
-        True, help="Crop and resize the images on the fly"
+        False, help="Crop and resize the images on the fly"
     ),
     compare_torch: bool = typer.Option(True, help="Compare against torch dataloader"),
 ):
     print(f"Running benchmark for {root_path} - {limit} samples")
+    print(
+        "Please run the benchmark twice if you want to compare against torch dataloader, so that file caching affects both paths"
+    )
+
     client_config = {
         "source_type": "file",
         "source_config": {"root_path": root_path},
@@ -81,8 +85,14 @@ def benchmark(
         )
 
         # Create a DataLoader to allow for multiple workers
+        # Use available CPU count for num_workers
+        num_workers = os.cpu_count() or 8  # Default to 8 if cpu_count returns None
         dataloader = DataLoader(
-            dataset, batch_size=1, shuffle=False, num_workers=8, collate_fn=lambda x: x
+            dataset,
+            batch_size=1,
+            shuffle=False,
+            num_workers=num_workers,
+            collate_fn=lambda x: x,
         )
 
         # Iterate over the DataLoader

--- a/src/generator_files.rs
+++ b/src/generator_files.rs
@@ -1,12 +1,10 @@
 use crate::client::DatagoClient;
-use crate::generator_http;
 use crate::structs::DatagoEngine;
 use crate::worker_files;
 use kanal::bounded;
 use log::debug;
 use rand::seq::SliceRandom;
 use serde::{Deserialize, Serialize};
-use std::cmp::min;
 use std::hash::Hash;
 use std::thread;
 
@@ -26,8 +24,8 @@ fn hash<T: Hash>(t: &T) -> u64 {
     s.finish()
 }
 
-fn ping_files(
-    pages_tx: kanal::Sender<serde_json::Value>,
+fn enumerate_files(
+    samples_metadata_tx: kanal::Sender<serde_json::Value>,
     source_config: SourceFileConfig,
     rank: usize,
     world_size: usize,
@@ -67,12 +65,8 @@ fn ping_files(
         files_list.into_iter()
     };
 
-    // Make sure that we always send at least one page
-    let page_size = min(50, limit);
-
-    // Iterate over the files and send the pages of files as they come
+    // Iterate over the files and send the paths as they come
     let mut count = 0;
-    let mut filepaths = Vec::new();
     let max_submitted_samples = (1.1 * (limit as f64)).ceil() as usize;
 
     // Build a page from the files iterator
@@ -88,23 +82,14 @@ fn ping_files(
             }
         }
 
-        filepaths.push(file_name);
-        count += 1;
-
-        if filepaths.len() >= page_size || count >= max_submitted_samples {
-            // Convert the page to a JSON
-            let page_json = serde_json::json!({
-                "results": filepaths,
-                "rank": rank,
-                "world_size": world_size,
-            });
-
-            // Push the page to the channel
-            if pages_tx.send(page_json).is_err() {
-                break;
-            }
-            filepaths.clear();
+        if samples_metadata_tx
+            .send(serde_json::Value::String(file_name))
+            .is_err()
+        {
+            break;
         }
+
+        count += 1;
 
         if count >= max_submitted_samples {
             // NOTE: This doesn´t count the samples which have actually been processed
@@ -120,7 +105,7 @@ fn ping_files(
     );
 
     // Send an empty value to signal the end of the stream
-    match pages_tx.send(serde_json::Value::Null) {
+    match samples_metadata_tx.send(serde_json::Value::Null) {
         Ok(_) => {}
         Err(_) => {
             debug!("ping_pages: stream already closed, all good");
@@ -129,45 +114,42 @@ fn ping_files(
 }
 
 pub fn orchestrate(client: &DatagoClient) -> DatagoEngine {
-    // Start pulling the samples, which spread across three steps. The samples will land in the last kanal,
+    // Start pulling the samples, which spread across two steps. The samples will land in the last kanal,
     // all the threads pausing when the required buffer depth is reached.
 
     // A first thread will query the filesystem and get pages of filepaths back
     // This meta data is then dispatched to a worker pool, which will load the files, deserialize them,
     // do the required pre-processing then commit to the ready queue.
 
-    // TODO: refactor to join with the same orchestration function in generator_http.rs
+    // TODO: Pass over an Arc ref of the client instead of doing the current member copies
 
     // Allocate all the message passing pipes
-    let (pages_tx, pages_rx) = bounded(2);
     let (samples_metadata_tx, samples_metadata_rx) = bounded(client.samples_buffer * 2);
     let (samples_tx, samples_rx) = bounded(client.samples_buffer);
 
     // Convert the source_config to a SourceFileConfig
     let source_config: SourceFileConfig =
         serde_json::from_value(client.source_config.clone()).unwrap();
-
     println!("Using file as source {}", source_config.root_path);
+
+    // Create a thread which will generate work as it goes. We'll query the filesystem
+    // and send the filepaths to the worker pool as we go
     let rank = client.rank;
     let limit = client.limit;
     let world_size = client.world_size;
 
-    let pinger = Some(thread::spawn(move || {
-        ping_files(pages_tx, source_config, rank, world_size, limit);
+    let generator = Some(thread::spawn(move || {
+        enumerate_files(samples_metadata_tx, source_config, rank, world_size, limit);
     }));
 
-    // Spawn a thread which will dispatch the pages to the workers
-    let pages_rx_feeder = pages_rx.clone();
-    let feeder = Some(thread::spawn(move || {
-        generator_http::dispatch_pages(pages_rx_feeder, samples_metadata_tx, limit);
-    }));
-
-    // Spawn a thread which will handle the async workers
+    // Spawn a thread which will handle the async workers through a mutlithread tokio runtime
     let image_transform = client.image_transform.clone();
     let encode_images = client.encode_images;
     let img_to_rgb8 = client.image_to_rgb8;
     let limit = client.limit;
     let samples_tx_worker = samples_tx.clone();
+    let samples_metadata_rx_worker = samples_metadata_rx.clone();
+
     let worker = Some(thread::spawn(move || {
         worker_files::pull_samples(
             samples_metadata_rx,
@@ -180,11 +162,11 @@ pub fn orchestrate(client: &DatagoClient) -> DatagoEngine {
     }));
 
     DatagoEngine {
-        pages_rx,
+        pages_rx: samples_metadata_rx_worker,
         samples_tx,
         samples_rx,
-        pinger,
-        feeder,
+        pinger: None,
+        feeder: generator,
         worker,
     }
 }

--- a/src/generator_files.rs
+++ b/src/generator_files.rs
@@ -116,10 +116,9 @@ fn enumerate_files(
 pub fn orchestrate(client: &DatagoClient) -> DatagoEngine {
     // Start pulling the samples, which spread across two steps. The samples will land in the last kanal,
     // all the threads pausing when the required buffer depth is reached.
-
-    // A first thread will query the filesystem and get pages of filepaths back
-    // This meta data is then dispatched to a worker pool, which will load the files, deserialize them,
-    // do the required pre-processing then commit to the ready queue.
+    // - A first thread will query the filesystem and get pages of filepaths back. It will dispatch the filepaths
+    // to the worker pool.
+    // - The worker pool will load the files, deserialize them, do the required pre-processing then commit to the ready queue.
 
     // TODO: Pass over an Arc ref of the client instead of doing the current member copies
 


### PR DESCRIPTION
Remove one thread which was just serving the files into another kanal, this arch was a remnant from the original golang implementation, doesn't make too much sense in this case. Better would now to have all the file front end async calls, so that the file dispatch can be concurrent to walking through the filesystem. 

Making the python test vs. torch more fair by allowing more CPUs to torch, but when caching is removed rust is still faster. Note that image processing even things out more or less, but the datago image proc is more qualitative

![Screenshot_20250508_235024](https://github.com/user-attachments/assets/34f34141-d6a7-4fb5-b917-bbda6a4192d9)
