### PR TITLE
[refactor] DB path : simpler setup, feeder thread does the dispatch, one less kanal

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -132,15 +132,8 @@ impl DatagoClient {
         }
 
         if let Some(engine) = &mut self.engine {
-            // let _ = engine.samples_meta_rx.close();
-            let _ = engine.pages_rx.close();
+            let _ = engine.samples_metadata_rx.close();
             let _ = engine.samples_tx.close();
-
-            if let Some(pinger) = engine.pinger.take() {
-                if pinger.join().is_err() {
-                    error!("Failed to join pinger thread");
-                }
-            }
 
             if let Some(feeder) = engine.feeder.take() {
                 if feeder.join().is_err() {

--- a/src/generator_files.rs
+++ b/src/generator_files.rs
@@ -137,7 +137,7 @@ pub fn orchestrate(client: &DatagoClient) -> DatagoEngine {
     let limit = client.limit;
     let world_size = client.world_size;
 
-    let generator = Some(thread::spawn(move || {
+    let feeder = Some(thread::spawn(move || {
         enumerate_files(samples_metadata_tx, source_config, rank, world_size, limit);
     }));
 
@@ -151,7 +151,7 @@ pub fn orchestrate(client: &DatagoClient) -> DatagoEngine {
 
     let worker = Some(thread::spawn(move || {
         worker_files::pull_samples(
-            samples_metadata_rx,
+            samples_metadata_rx_worker,
             samples_tx_worker,
             image_transform,
             encode_images,
@@ -161,11 +161,10 @@ pub fn orchestrate(client: &DatagoClient) -> DatagoEngine {
     }));
 
     DatagoEngine {
-        pages_rx: samples_metadata_rx_worker,
+        samples_metadata_rx,
         samples_tx,
         samples_rx,
-        pinger: None,
-        feeder: generator,
+        feeder,
         worker,
     }
 }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -33,11 +33,10 @@ pub struct DatagoClientConfig {
 
 #[derive(Debug)]
 pub struct DatagoEngine {
-    pub pages_rx: kanal::Receiver<serde_json::Value>,
+    pub samples_metadata_rx: kanal::Receiver<serde_json::Value>,
     pub samples_tx: kanal::Sender<Option<Sample>>,
     pub samples_rx: kanal::Receiver<Option<Sample>>,
 
-    pub pinger: Option<thread::JoinHandle<()>>,
     pub feeder: Option<thread::JoinHandle<()>>,
     pub worker: Option<thread::JoinHandle<()>>,
 }


### PR DESCRIPTION
related to #115 and #111, aligning all the paths towards a simpler setup, removing a kanal which really came from the golang implementation. Code is slightly more compact, one less thread to explicitly join, one less synchronization to pass, I think we're better for it 