### PR TITLE
Fix file dispatch + more modern string interp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "datago"
-version = "2025.6.5"
+version = "2025.6.6"
 dependencies = [
  "async-compression",
  "async-tar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "datago"
 edition = "2021"
-version = "2025.6.5"
+version = "2025.6.6"
 
 [lib]
 # exposed by pyo3

--- a/src/client.rs
+++ b/src/client.rs
@@ -61,7 +61,7 @@ impl DatagoClient {
                 }
             }
             Err(e) => {
-                panic!("Failed to parse config: {}", e);
+                panic!("Failed to parse config: {e}");
             }
         }
     }
@@ -120,7 +120,7 @@ impl DatagoClient {
                     }
                 },
                 Err(e) => {
-                    warn!("Timeout waiting for sample, stopping the client. {}", e);
+                    warn!("Timeout waiting for sample, stopping the client. {e}");
                     self.stop();
                     None
                 }
@@ -514,7 +514,7 @@ mod tests {
         let mut config = get_test_config();
         let tag1 = "photo";
         let tag2 = "graphic";
-        config["source_config"]["tags_ne_all"] = format!("{},{}", tag1, tag2).into();
+        config["source_config"]["tags_ne_all"] = format!("{tag1},{tag2}").into();
         let mut client = DatagoClient::new(config.to_string());
 
         let sample = client.get_sample();
@@ -599,7 +599,7 @@ mod tests {
         config["source_config"]["sources_ne"] = "LAION_ART".into();
         config["limit"] = json!(limit);
 
-        debug!("{}", config);
+        debug!("{config}");
         let mut client = DatagoClient::new(config.to_string());
 
         for _ in 0..limit {

--- a/src/generator_http.rs
+++ b/src/generator_http.rs
@@ -130,9 +130,9 @@ struct DbRequest {
 impl DbRequest {
     async fn get_http_request(&self, api_url: &str, api_key: &str) -> reqwest::Request {
         let mut url = if self.random_sampling {
-            Url::parse(&format!("{}images/random/", api_url))
+            Url::parse(&format!("{api_url}images/random/"))
         } else {
-            Url::parse(&format!("{}images/", api_url))
+            Url::parse(&format!("{api_url}images/"))
         }
         .unwrap(); // Cannot survive without the URL, that's a panic
 
@@ -183,7 +183,7 @@ impl DbRequest {
         let mut req = reqwest::Request::new(reqwest::Method::GET, url);
         req.headers_mut().append(
             AUTHORIZATION,
-            HeaderValue::from_str(&format!("Token {}", api_key))
+            HeaderValue::from_str(&format!("Token {api_key}"))
                 .expect("Couldn't parse the provided API key"),
         );
 
@@ -276,7 +276,7 @@ fn build_request(source_config: SourceDBConfig) -> DbRequest {
         "Rank cannot be greater than or equal to world size"
     );
 
-    debug!("Fields: {}", fields);
+    debug!("Fields: {fields}");
     debug!(
         "Rank: {}, World size: {}",
         source_config.rank, source_config.world_size
@@ -363,7 +363,7 @@ async fn async_pull_and_dispatch_pages(
     let mut headers = HeaderMap::new();
     headers.insert(
         AUTHORIZATION,
-        HeaderValue::from_str(&format!("Token  {}", api_key)).unwrap(),
+        HeaderValue::from_str(&format!("Token  {api_key}")).unwrap(),
     );
 
     let db_request = build_request(source_config.clone());
@@ -380,7 +380,7 @@ async fn async_pull_and_dispatch_pages(
             if let Some(next) = response_json.get("next") {
                 next_url = next;
             } else {
-                debug!("No next URL in the response {:?}", response_json);
+                debug!("No next URL in the response {response_json:?}");
             }
         }
         Err(e) => {
@@ -420,7 +420,7 @@ async fn async_pull_and_dispatch_pages(
                 }
             }
             None => {
-                debug!("No results in the response: {:?}", response_json);
+                debug!("No results in the response: {response_json:?}");
             }
         }
 
@@ -455,8 +455,7 @@ async fn async_pull_and_dispatch_pages(
 
     // Either we don't have any more samples or we have reached the limit
     debug!(
-        "pull_and_dispatch_pages: total samples requested: {}. page samples served {}",
-        limit, count
+        "pull_and_dispatch_pages: total samples requested: {limit}. page samples served {count}"
     );
 
     // Send an empty value to signal the end of the stream

--- a/src/image_processing.rs
+++ b/src/image_processing.rs
@@ -59,10 +59,7 @@ impl ImageTransformConfig {
             self.max_aspect_ratio,
         );
 
-        debug!(
-            "Cropping and resizing images. Target image sizes:\n{:?}\n",
-            target_image_sizes
-        );
+        debug!("Cropping and resizing images. Target image sizes:\n{target_image_sizes:?}\n");
 
         let mut aspect_ratio_to_size = std::collections::HashMap::new();
         for img_size in &target_image_sizes {
@@ -325,12 +322,7 @@ pub async fn image_to_payload(
             image.height(),
             image.color().into(),
         )
-        .map_err(|e| {
-            image::ImageError::IoError(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                e.to_string(),
-            ))
-        })?;
+        .map_err(std::io::Error::other)?;
 
         channels = -1; // Signal the fact that the image is encoded
     } else {
@@ -687,8 +679,8 @@ mod tests {
 
         // Fill with some test data
         let buffer = img.buffer_mut();
-        for i in 0..buffer.len() {
-            buffer[i] = (i % 256) as u8;
+        for (i, item) in buffer.iter_mut().enumerate() {
+            *item = (i % 256) as u8;
         }
 
         let dyn_img = image_to_dyn_image(&img);
@@ -704,8 +696,8 @@ mod tests {
         let mut img = Image::new(width, height, fr::PixelType::U8x4);
 
         let buffer = img.buffer_mut();
-        for i in 0..buffer.len() {
-            buffer[i] = ((i * 63) % 256) as u8;
+        for (i, item) in buffer.iter_mut().enumerate() {
+            *item = ((i * 63) % 256) as u8;
         }
 
         let dyn_img = image_to_dyn_image(&img);
@@ -721,8 +713,8 @@ mod tests {
         let mut img = Image::new(width, height, fr::PixelType::U8);
 
         let buffer = img.buffer_mut();
-        for i in 0..buffer.len() {
-            buffer[i] = (i % 256) as u8;
+        for (i, item) in buffer.iter_mut().enumerate() {
+            *item = (i % 256) as u8;
         }
 
         let dyn_img = image_to_dyn_image(&img);

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,7 +119,7 @@ fn main() {
         "samples_buffer_size": samples_buffer_size
     });
 
-    info!("{}", config);
+    info!("{config}");
 
     let mut client = client::DatagoClient::new(config.to_string());
 
@@ -141,7 +141,7 @@ fn main() {
             }
             if save_samples {
                 let img = image::load_from_memory(&sample.image.data).unwrap();
-                let filename = format!("sample_{:?}.jpg", num_samples_received);
+                let filename = format!("sample_{num_samples_received:?}.jpg");
                 img.save(filename).unwrap();
             }
             num_samples_received += 1;
@@ -160,18 +160,15 @@ fn main() {
         }
     }
     client.stop();
-    info!(
-        "All samples processed. Got {:?} samples\n",
-        num_samples_received
-    );
+    info!("All samples processed. Got {num_samples_received:?} samples\n");
 
     // Report the per-bucket occupancy, good sanity check
     if crop_and_resize {
         let mut size_buckets_str = String::from("Size buckets:\n");
         for (size, count) in size_buckets.iter() {
-            size_buckets_str.push_str(&format!("{}: {}\n", size, count));
+            size_buckets_str.push_str(&format!("{size}: {count}\n"));
         }
-        info!("{}", size_buckets_str);
+        info!("{size_buckets_str}");
     }
 
     let elapsed_secs = start_time.elapsed().as_secs_f64();

--- a/src/worker_files.rs
+++ b/src/worker_files.rs
@@ -6,9 +6,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 async fn image_from_path(path: &str) -> Result<image::DynamicImage, image::ImageError> {
-    let bytes = std::fs::read(path).map_err(|e| {
-        image::ImageError::IoError(std::io::Error::new(std::io::ErrorKind::Other, e))
-    })?;
+    let bytes =
+        std::fs::read(path).map_err(|e| image::ImageError::IoError(std::io::Error::other(e)))?;
 
     image::load_from_memory(&bytes)
 }
@@ -70,7 +69,7 @@ async fn pull_sample(
             Ok(())
         }
         Err(e) => {
-            error!("Failed to load image from path {} {}", sample_json, e);
+            error!("Failed to load image from path {sample_json} {e}");
             Err(())
         }
     }
@@ -125,7 +124,7 @@ async fn async_pull_samples(
             debug!("file_worker: task failed or was cancelled");
         }
     });
-    debug!("file_worker: total samples sent: {}\n", count);
+    debug!("file_worker: total samples sent: {count}\n");
 
     // Signal the end of the stream
     if samples_tx.send(None).is_ok() {};
@@ -349,7 +348,7 @@ mod tests {
         // Create multiple test images
         let mut image_paths = Vec::new();
         for i in 0..3 {
-            let image_path = temp_dir.path().join(format!("test_{}.png", i));
+            let image_path = temp_dir.path().join(format!("test_{i}.png"));
             create_test_image(&image_path);
             image_paths.push(image_path.to_str().unwrap().to_string());
         }
@@ -391,7 +390,7 @@ mod tests {
 
         // Create more images than the limit
         for i in 0..10 {
-            let image_path = temp_dir.path().join(format!("test_{}.png", i));
+            let image_path = temp_dir.path().join(format!("test_{i}.png"));
             create_test_image(&image_path);
         }
 
@@ -400,7 +399,7 @@ mod tests {
 
         // Send more paths than the limit
         for i in 0..10 {
-            let path = temp_dir.path().join(format!("test_{}.png", i));
+            let path = temp_dir.path().join(format!("test_{i}.png"));
             metadata_tx
                 .send(serde_json::Value::String(
                     path.to_str().unwrap().to_string(),

--- a/src/worker_wds.rs
+++ b/src/worker_wds.rs
@@ -102,7 +102,7 @@ async fn process_sample(
                                 debug!("wds_worker: unpacked {}", item.filename);
                             }
                             Err(e) => {
-                                debug!("wds_worker: error loading image: {}", e);
+                                debug!("wds_worker: error loading image: {e}");
                                 continue;
                             }
                         }
@@ -142,7 +142,7 @@ async fn async_deserialize_samples(
     // We use async-await here, to better use IO stalls
     // We'll keep a pool of N async tasks in parallel
     let max_tasks = min(num_cpus::get(), limit);
-    info!("Using {} tasks in the async threadpool", max_tasks);
+    info!("Using {max_tasks} tasks in the async threadpool");
     let mut tasks = tokio::task::JoinSet::new();
     let mut count = 0;
     let shareable_channel_tx: Arc<kanal::Sender<Option<Sample>>> = Arc::new(samples_tx);
@@ -172,7 +172,7 @@ async fn async_deserialize_samples(
                 match result {
                     Ok(_) => count += 1,
                     Err(e) => {
-                        join_error = Some(format!("Task failed: {}", e));
+                        join_error = Some(format!("Task failed: {e}"));
                         break;
                     }
                 }
@@ -192,7 +192,7 @@ async fn async_deserialize_samples(
                 count += 1;
             }
             Err(e) => {
-                error!("dispatch_shards: task failed with error: {:?}", e);
+                error!("dispatch_shards: task failed with error: {e}");
                 if join_error.is_none() {
                     join_error = Some(e.to_string());
                 }
@@ -200,16 +200,13 @@ async fn async_deserialize_samples(
         }
     }
 
-    info!("wds_worker: total samples sent: {}\n", count);
+    info!("wds_worker: total samples sent: {count}\n");
 
     // Signal the end of the stream
     let _ = shareable_channel_tx.send(None); // Channel could have been closed by a .stop() call
 
     if let Some(error) = join_error {
-        error!(
-            "wds_worker: encountered an error while processing samples: {}",
-            error
-        );
+        error!("wds_worker: encountered an error while processing samples: {error}");
         return Err(error);
     }
     Ok(())
@@ -242,7 +239,7 @@ pub fn deserialize_samples(
             .await
             {
                 Ok(_) => debug!("wds_worker: all samples processed successfully"),
-                Err(e) => error!("wds_worker: error processing samples : {:?}", e),
+                Err(e) => error!("wds_worker: error processing samples : {e}"),
             }
         });
 }


### PR DESCRIPTION
- remove the hash function to dispatch files, unit test was not very robust (hash function would not dispatch very close filenames to different  enough hashes) & a simpler way to do this is to deterministically chunk the file list. 
  - Note that this was not an option beforehand, as datago didn´t materialize the file list, but it does since supporting complete file shuffling. This has a startup cost if there are a lot of files in the folder, could be handled differently in the future

- [no changes] move the string interpolation to more modern in place, was enforced by clippy

Note that actual motivation was to add io_uring support to the file loading path, but this will be for another PR :) Should make it as fast as possible basically, but I stumbled upon unreliable unit test so I figured I should fix it first. cc @photoroman 