### PR TITLE
[nit] Removing uv complaint that version is undefined

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,16 @@
 [project]
 name = "datago"
-authors = [
-  { name="Photoroom", email="team@photoroom.com" },
-]
+dynamic = ["version"]
+authors = [{ name = "Photoroom", email = "team@photoroom.com" }]
 description = "A high performance dataloader for Python, written in Rust"
 readme = "README.md"
 requires-python = ">=3.8"
 classifiers = [
-    "Programming Language :: Rust",
-    "Programming Language :: Python :: Implementation :: CPython",
-    "Programming Language :: Python :: Implementation :: PyPy",
-    "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
+  "Programming Language :: Rust",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: MIT License",
 ]
 dependencies = []
 


### PR DESCRIPTION
project.version needs to be defined, else it needs to be part of the "dynamic" fields, as part of the pyproject specs it seems